### PR TITLE
Pass click events "through" non-interactive 1-way layer

### DIFF
--- a/web/src/layers/OneWayLayer.svelte
+++ b/web/src/layers/OneWayLayer.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { SymbolLayer } from "svelte-maplibre";
   import { layerId } from "../common";
+
+  // TODO Figure out if hoverCursor is necessary here, or if svelte-maplibre
+  // ignores it when interactive is false
 </script>
 
 <SymbolLayer

--- a/web/src/layers/OneWayLayer.svelte
+++ b/web/src/layers/OneWayLayer.svelte
@@ -21,4 +21,6 @@
   paint={{
     "icon-opacity": ["case", ["get", "direction_edited"], 1.0, 0.5],
   }}
+  interactive={false}
+  hoverCursor="pointer"
 />


### PR DESCRIPTION
I was just kind of exploring the maplibre svelte library and randomly saw this `interactive = false`, which seems to solve a problem you mentioned the other day @dabreegster.

Your clicks will no longer be "intercepted" by the 1-way layer symbols.

**before:** you can see the hover effect turn off for the road every time you hover over a 1-way glyph.
![](https://github.com/user-attachments/assets/41f84d61-9bcf-4232-8e11-70aa25d56401)


**after:**
![](https://github.com/user-attachments/assets/e501fdb1-9a49-43cc-b614-9872c5a8099c)

But oops! The cursor is no longer what we want, so I had to specify the cursor for the 1-way layer. It's weird, but it seems to work. Do you know if we use the 1way layer in any non-interactive contexts where we *should not* show the pointer cursor?

![](https://github.com/user-attachments/assets/b513aed6-7f6d-4438-957f-1cbcf1516729)
