### PR TITLE
Start modelling movements at intersections

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/a-b-street/utils#5abc185bbe7c9d67c8a064e3357a6365688f4bec"
+source = "git+https://github.com/a-b-street/utils#10d8bf23282fb601ffc3eeb78b5ea8b9b1acd496"
 dependencies = [
  "anyhow",
  "fast_paths",

--- a/backend/src/geo_helpers.rs
+++ b/backend/src/geo_helpers.rs
@@ -214,6 +214,20 @@ pub fn make_arrow(line: Line, thickness: f64, double_ended: bool) -> Option<Poly
     Some(Polygon::new(LineString::new(pts), Vec::new()))
 }
 
+pub fn thicken_line(line: Line, thickness: f64) -> Polygon {
+    let angle = angle_of_line(line);
+    Polygon::new(
+        LineString::new(vec![
+            euclidean_destination_coord(line.start, angle - 90.0, thickness * 0.5),
+            euclidean_destination_coord(line.end, angle - 90.0, thickness * 0.5),
+            euclidean_destination_coord(line.end, angle + 90.0, thickness * 0.5),
+            euclidean_destination_coord(line.start, angle + 90.0, thickness * 0.5),
+            euclidean_destination_coord(line.start, angle - 90.0, thickness * 0.5),
+        ]),
+        Vec::new(),
+    )
+}
+
 /// Create a polygon covering the world, minus a hole for the input polygon. Assumes the input is
 /// in WGS84 and has no holes itself.
 pub fn invert_polygon(wgs84_polygon: Polygon) -> Polygon {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -25,6 +25,7 @@ mod create;
 mod geo_helpers;
 mod impact;
 mod map_model;
+mod movements;
 mod neighbourhood;
 mod render_cells;
 mod route;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -327,7 +327,11 @@ impl LTN {
             self.map
                 .intersections
                 .iter()
-                .map(|i| self.map.mercator.to_wgs84_gj(&i.point))
+                .map(|i| {
+                    let mut f = self.map.mercator.to_wgs84_gj(&i.point);
+                    f.set_property("has_turn_restrictions", !i.turn_restrictions.is_empty());
+                    f
+                })
                 .collect::<Vec<_>>(),
         ))
         .map_err(err_to_js)?)

--- a/backend/src/map_model.rs
+++ b/backend/src/map_model.rs
@@ -86,10 +86,11 @@ pub struct Road {
 
 pub struct Intersection {
     pub id: IntersectionID,
-    #[allow(unused)]
     pub node: osm_reader::NodeID,
     pub point: Point,
     pub roads: Vec<RoadID>,
+    /// (from, to) is not allowed. May be redundant with the road directions.
+    pub turn_restrictions: Vec<(RoadID, RoadID)>,
 }
 
 impl MapModel {

--- a/backend/src/map_model.rs
+++ b/backend/src/map_model.rs
@@ -581,17 +581,6 @@ impl MapModel {
         }
         directions
     }
-
-    pub fn get_movements(&self, i: IntersectionID) -> GeoJson {
-        let mut features = Vec::new();
-
-        // TODO Temporary
-        for r in &self.get_i(i).roads {
-            features.push(self.mercator.to_wgs84_gj(&self.get_r(*r).linestring));
-        }
-
-        GeoJson::from(features)
-    }
 }
 
 impl Road {

--- a/backend/src/movements.rs
+++ b/backend/src/movements.rs
@@ -1,0 +1,42 @@
+use geo::{Line, LineInterpolatePoint};
+use geojson::GeoJson;
+
+use crate::{
+    geo_helpers::{make_arrow, thicken_line},
+    IntersectionID, MapModel,
+};
+
+impl MapModel {
+    pub fn get_movements(&self, i: IntersectionID) -> GeoJson {
+        let mut features = Vec::new();
+
+        for r1 in &self.get_i(i).roads {
+            for r2 in &self.get_i(i).roads {
+                if r1 == r2 {
+                    continue;
+                }
+                let road1 = self.get_r(*r1);
+                let road2 = self.get_r(*r2);
+
+                let pt1 = road1
+                    .linestring
+                    .line_interpolate_point(if road1.src_i == i { 0.3 } else { 0.7 })
+                    .unwrap();
+                let pt2 = road2
+                    .linestring
+                    .line_interpolate_point(if road2.src_i == i { 0.3 } else { 0.7 })
+                    .unwrap();
+
+                let thickness = 2.0;
+                let double_ended = false;
+                let line = Line::new(pt1, pt2);
+
+                let polygon = make_arrow(line, thickness, double_ended)
+                    .unwrap_or_else(|| thicken_line(line, thickness));
+                features.push(self.mercator.to_wgs84_gj(&polygon));
+            }
+        }
+
+        GeoJson::from(features)
+    }
+}

--- a/backend/src/movements.rs
+++ b/backend/src/movements.rs
@@ -3,7 +3,7 @@ use geojson::GeoJson;
 
 use crate::{
     geo_helpers::{make_arrow, thicken_line},
-    IntersectionID, MapModel,
+    Direction, IntersectionID, MapModel,
 };
 
 impl MapModel {
@@ -18,13 +18,29 @@ impl MapModel {
                 let road1 = self.get_r(*r1);
                 let road2 = self.get_r(*r2);
 
+                // If road1 is one-way, can we go towards i?
+                let ok1 = match self.directions[r1] {
+                    Direction::BothWays => true,
+                    Direction::Forwards => road1.dst_i == i,
+                    Direction::Backwards => road1.src_i == i,
+                };
+                // If road2 is one-way, can we go away from i?
+                let ok2 = match self.directions[r2] {
+                    Direction::BothWays => true,
+                    Direction::Forwards => road2.src_i == i,
+                    Direction::Backwards => road2.dst_i == i,
+                };
+                if !ok1 || !ok2 {
+                    continue;
+                }
+
                 let pt1 = road1
                     .linestring
-                    .line_interpolate_point(if road1.src_i == i { 0.3 } else { 0.7 })
+                    .line_interpolate_point(if road1.src_i == i { 0.2 } else { 0.8 })
                     .unwrap();
                 let pt2 = road2
                     .linestring
-                    .line_interpolate_point(if road2.src_i == i { 0.3 } else { 0.7 })
+                    .line_interpolate_point(if road2.src_i == i { 0.2 } else { 0.8 })
                     .unwrap();
 
                 let thickness = 2.0;

--- a/web/src/DebugIntersectionsMode.svelte
+++ b/web/src/DebugIntersectionsMode.svelte
@@ -9,13 +9,15 @@
   import { emptyGeojson } from "svelte-utils/map";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
   import BackButton from "./BackButton.svelte";
-  import { layerId, Link } from "./common";
+  import { layerId, Link, PrevNext } from "./common";
   import { backend, mode } from "./stores";
 
   let movements = emptyGeojson();
+  let idx = 0;
 
   function pickIntersection(e: CustomEvent<LayerClickInfo>) {
     movements = $backend!.getMovements(e.detail.features[0].id as number);
+    idx = 0;
   }
 </script>
 
@@ -40,7 +42,8 @@
       <button class="secondary" on:click={() => (movements = emptyGeojson())}>
         Pick another intersection
       </button>
-      <p>{movements.features.length} movements</p>
+
+      <PrevNext list={movements.features} bind:idx />
     {/if}
   </div>
 
@@ -63,7 +66,7 @@
         {...layerId("debug-movements")}
         paint={{
           "line-width": 2,
-          "line-color": "red",
+          "line-color": ["case", ["==", ["id"], idx], "cyan", "red"],
         }}
       />
     </GeoJSON>

--- a/web/src/DebugIntersectionsMode.svelte
+++ b/web/src/DebugIntersectionsMode.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
     CircleLayer,
+    FillLayer,
     GeoJSON,
     LineLayer,
     type LayerClickInfo,
@@ -63,10 +64,18 @@
 
     <GeoJSON data={movements} generateId>
       <LineLayer
-        {...layerId("debug-movements")}
+        {...layerId("debug-movements-outline")}
         paint={{
           "line-width": 2,
-          "line-color": ["case", ["==", ["id"], idx], "cyan", "red"],
+          "line-color": "red",
+        }}
+      />
+
+      <FillLayer
+        {...layerId("debug-movements-fill")}
+        filter={["==", ["id"], idx]}
+        paint={{
+          "fill-color": "cyan",
         }}
       />
     </GeoJSON>

--- a/web/src/DebugIntersectionsMode.svelte
+++ b/web/src/DebugIntersectionsMode.svelte
@@ -31,6 +31,11 @@
             Choose project
           </Link>
         </li>
+        <li>
+          <Link on:click={() => ($mode = { mode: "network" })}>
+            Pick neighbourhood
+          </Link>
+        </li>
         <li>Debug intersections</li>
       </ul>
     </nav>
@@ -38,6 +43,8 @@
 
   <div slot="sidebar">
     <BackButton on:click={() => ($mode = { mode: "network" })} />
+
+    <p>Purple intersections have some kind of turn restriction.</p>
 
     {#if movements.features.length > 0}
       <button class="secondary" on:click={() => (movements = emptyGeojson())}>
@@ -54,7 +61,12 @@
         {...layerId("debug-intersections")}
         paint={{
           "circle-radius": 15,
-          "circle-color": "black",
+          "circle-color": [
+            "case",
+            ["get", "has_turn_restrictions"],
+            "purple",
+            "black",
+          ],
         }}
         manageHoverState
         hoverCursor="pointer"

--- a/web/src/ImpactDetailMode.svelte
+++ b/web/src/ImpactDetailMode.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
   import type { Feature, FeatureCollection } from "geojson";
-  import { onDestroy, onMount } from "svelte";
   import { GeoJSON, LineLayer } from "svelte-maplibre";
   import { constructMatchExpression } from "svelte-utils/map";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
-  import { DotMarker, gjPosition, layerId, Link } from "./common";
+  import { DotMarker, gjPosition, layerId, Link, PrevNext } from "./common";
   import { ModalFilterLayer } from "./layers";
-  import { backend, map, mode } from "./stores";
+  import { backend, mode } from "./stores";
 
   export let road: Feature;
 
@@ -16,36 +15,6 @@
   let routes = $backend!.getImpactsOnRoad(road.properties!.id);
   let idx = 0;
 
-  onMount(() => {
-    $map?.keyboard.disable();
-  });
-  onDestroy(() => {
-    $map?.keyboard.enable();
-  });
-
-  function onKeyDown(e: KeyboardEvent) {
-    if (e.key == "ArrowLeft") {
-      e.stopPropagation();
-      prev();
-    }
-    if (e.key == "ArrowRight") {
-      e.stopPropagation();
-      next();
-    }
-  }
-
-  function prev() {
-    if (idx != 0) {
-      idx--;
-    }
-  }
-
-  function next() {
-    if (idx != routes.length - 1) {
-      idx++;
-    }
-  }
-
   function gj(idx: number): FeatureCollection {
     return {
       type: "FeatureCollection" as const,
@@ -53,8 +22,6 @@
     };
   }
 </script>
-
-<svelte:window on:keydown={onKeyDown} />
 
 <SplitComponent>
   <div slot="top">
@@ -80,19 +47,7 @@
       Pick a different road
     </Link>
 
-    <div style="display: flex; justify-content: space-between;">
-      <button disabled={idx == 0} on:click={prev} data-tooltip="Left">
-        Previous
-      </button>
-      {idx + 1} / {routes.length}
-      <button
-        disabled={idx == routes.length - 1}
-        on:click={next}
-        data-tooltip="Right"
-      >
-        Next
-      </button>
-    </div>
+    <PrevNext list={routes} bind:idx />
 
     <p>
       <span style="color: red">Route before</span>

--- a/web/src/common/PrevNext.svelte
+++ b/web/src/common/PrevNext.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import { map } from "../stores";
+
+  export let list: any[];
+  export let idx = 0;
+
+  onMount(() => {
+    $map?.keyboard.disable();
+  });
+  onDestroy(() => {
+    $map?.keyboard.enable();
+  });
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.key == "ArrowLeft") {
+      e.stopPropagation();
+      prev();
+    }
+    if (e.key == "ArrowRight") {
+      e.stopPropagation();
+      next();
+    }
+  }
+
+  function prev() {
+    if (idx != 0) {
+      idx--;
+    }
+  }
+
+  function next() {
+    if (idx != list.length - 1) {
+      idx++;
+    }
+  }
+</script>
+
+<svelte:window on:keydown={onKeyDown} />
+
+<div style="display: flex; justify-content: space-between;">
+  <button disabled={idx == 0} on:click={prev} data-tooltip="Left">
+    Previous
+  </button>
+  {idx + 1} / {list.length}
+  <button
+    disabled={idx == list.length - 1}
+    on:click={next}
+    data-tooltip="Right"
+  >
+    Next
+  </button>
+</div>

--- a/web/src/common/index.ts
+++ b/web/src/common/index.ts
@@ -5,6 +5,7 @@ export { default as DisableInteractiveLayers } from "./DisableInteractiveLayers.
 export { default as DotMarker } from "./DotMarker.svelte";
 export { default as HelpButton } from "./HelpButton.svelte";
 export { default as Link } from "./Link.svelte";
+export { default as PrevNext } from "./PrevNext.svelte";
 export { default as StreetView } from "./StreetView.svelte";
 export { layerId } from "./zorder";
 

--- a/web/src/common/zorder.ts
+++ b/web/src/common/zorder.ts
@@ -87,7 +87,8 @@ const layerZorder = [
   "debug-filters",
 
   "debug-intersections",
-  "debug-movements",
+  "debug-movements-outline",
+  "debug-movements-fill",
 
   "cells",
   "interior-roads-outlines",

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -180,7 +180,7 @@ export class Backend {
     return JSON.parse(this.inner.getAllIntersections());
   }
 
-  getMovements(intersection: number): FeatureCollection<LineString> {
+  getMovements(intersection: number): FeatureCollection<Polygon> {
     return JSON.parse(this.inner.getMovements(intersection));
   }
 }

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -176,7 +176,10 @@ export class Backend {
     return JSON.parse(this.inner.getImpactsOnRoad(road));
   }
 
-  getAllIntersections(): FeatureCollection<Point> {
+  getAllIntersections(): FeatureCollection<
+    Point,
+    { has_turn_restrictions: boolean }
+  > {
     return JSON.parse(this.inner.getAllIntersections());
   }
 


### PR DESCRIPTION
Part of #30 (with some TODOs there) and also necessary for #41. This adds a debug mode (from the "pick neighbourhood" page) to understand movements at each intersection. They're generated by looking at one-way directions and the simplest OSM turn restriction cases. Only used in this debug mode right now, not yet for routing.
![image](https://github.com/user-attachments/assets/b602dcf5-3948-48d7-bf81-dfec4acf91ad)

It's going to be much easier to flesh this out with a better unit testing story. I'm thinking of manually drawing / clipping some test cases in JOSM, checking those in here. For movements, maybe the output can be expressed in the code as a list of movements between named roads, or maybe some GeoJSON / SVG output would be faster to understand.