### PR TITLE
Fix tests, CI fetches data with dev script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,19 +19,7 @@ jobs:
           key: cargo-test-${{ hashFiles('backend/Cargo.lock') }}
 
       - name: Download test inputs
-        run: |
-          cd web/public
-
-          mkdir osm
-          cd osm
-          wget https://assets.od2net.org/severance_pbfs/bristol.pbf
-          wget https://assets.od2net.org/severance_pbfs/strasbourg.pbf
-
-          cd ..
-          mkdir boundaries
-          cd boundaries
-          wget https://assets.od2net.org/boundaries/bristol.geojson
-          wget https://assets.od2net.org/boundaries/strasbourg.geojson
+        run: bin/download-local-test-data.sh
 
       - name: Run tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Tests
 on:
   push:
     branches: [main]
+  pull_request:
 
 jobs:
   build:

--- a/backend/src/test_fixtures.rs
+++ b/backend/src/test_fixtures.rs
@@ -35,7 +35,7 @@ impl NeighbourhoodFixture {
     pub fn map_model_builder(&self) -> Result<impl Fn() -> Result<MapModel> + use<'_>> {
         let study_area_name = &self.study_area_name;
 
-        let pbf_path = format!("../web/public/osm/{study_area_name}.pbf");
+        let pbf_path = format!("../web/public/severance_pbfs/{study_area_name}.pbf");
         let input_bytes = std::fs::read(&pbf_path)?;
 
         let boundary_path = format!("../web/public/boundaries/{study_area_name}.geojson");

--- a/bin/download-local-dev-data.sh
+++ b/bin/download-local-dev-data.sh
@@ -4,27 +4,20 @@
 # For expediency and deterministic tests, this script downloads some
 # pre-configured areas, which the web app will load from localhost.
 
-cd "$(git rev-parse --show-toplevel)"
+APP_ROOT=$(git rev-parse --show-toplevel)
+
+./bin/download-local-test-data.sh
 
 download_to_subdir() {
     local subdir=$1
     local url=$2
 
     mkdir -p "$subdir"
-    (wget -P "$subdir" --timestamping "$url" && echo "✅ $url") \
-        || echo "❌ Download failed: $url"
+    (wget -P "$subdir" --timestamping "$url" && echo "✅ (CNT) $url") \
+        || echo "❌ (CNT) Download failed: $url"
 }
 
-cd web/public
-
-download_to_subdir osm https://assets.od2net.org/severance_pbfs/areas.json
-
-# Global data used for tests and demo data
-AREAS="bristol edinburgh strasbourg ut_dallas"
-for x in $AREAS; do
-    download_to_subdir severance_pbfs "https://assets.od2net.org/severance_pbfs/$x.pbf"
-    download_to_subdir boundaries "https://assets.od2net.org/boundaries/$x.geojson"
-done
+cd "${APP_ROOT}/web/public"
 
 # Scotland specific data
 jq '.features[] | .properties.kind + "_" + .properties.name' ../../data_prep/scotland/boundaries.geojson | sed 's/"//g' | while read x; do

--- a/bin/download-local-test-data.sh
+++ b/bin/download-local-test-data.sh
@@ -1,0 +1,27 @@
+# "normally" the app downloads the latest data from Overpass API based on the
+# user's clipped areas.
+#
+# For expediency and deterministic tests, this script downloads some
+# pre-configured areas, which the web app will load from localhost.
+
+APP_ROOT=$(git rev-parse --show-toplevel)
+
+download_to_subdir() {
+    local subdir=$1
+    local url=$2
+
+    mkdir -p "$subdir"
+    (wget -P "$subdir" --timestamping "$url" && echo "✅ $url") \
+        || echo "❌ Download failed: $url"
+}
+
+cd "${APP_ROOT}/web/public"
+
+download_to_subdir osm https://assets.od2net.org/severance_pbfs/areas.json
+
+# Global data used for tests and demo data
+AREAS="bristol edinburgh strasbourg ut_dallas"
+for x in $AREAS; do
+    download_to_subdir severance_pbfs "https://assets.od2net.org/severance_pbfs/$x.pbf"
+    download_to_subdir boundaries "https://assets.od2net.org/boundaries/$x.geojson"
+done


### PR DESCRIPTION
#107 changed where the pbfs live, but we didn't update the unit tests, so those are failing locally now.

Ironically, because we *also* didn't change the CI script to match our new developer layout, CI continued to pass.

In #108 I added a script to download all the useful dev data. I wanted to use that script in CI to fetch data in the same way we're using it locally, but the dev data is quite large (500MB+), so I've broken out a `fetch_test_data` subscript that fetches only the data we need for testing (20MB or so).
