### PR TITLE
Start some minimal OSM unit tests

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -28,6 +28,8 @@ mod map_model;
 mod movements;
 mod neighbourhood;
 pub mod od;
+#[cfg(test)]
+mod osm_tests;
 mod render_cells;
 mod route;
 mod route_snapper;

--- a/backend/src/osm_tests/README.md
+++ b/backend/src/osm_tests/README.md
@@ -13,4 +13,8 @@ Importing existing modal filters and turn restrictions from OSM can be very comp
 
 ## Viewing the OSM unit test inputs
 
-TODO
+To understand a unit test input:
+
+-  Just manually read it -- many are small enough to understand
+-  Load in <https://dabreegster.github.io/geojson-viewer/> -- but note relations don't show up
+-  Use JOSM

--- a/backend/src/osm_tests/README.md
+++ b/backend/src/osm_tests/README.md
@@ -1,0 +1,16 @@
+# OSM unit tests
+
+Importing existing modal filters and turn restrictions from OSM can be very complicated. This directory contains minimal synthetic OSM inputs to test different situations.
+
+## Creating a unit test
+
+1.  Open the iD editor and zoom in on an empty patch of ocean, [like here](https://www.openstreetmap.org/edit#map=17/55.704282/-0.110917)
+2.  Create the simplest example for some test case
+3.  Press **Save** in the top-right corner
+4.  Go to the bottom and **Download osmChange file**. Do **not** actually upload this edit!
+5.  Turn the .osc into osm.xml and add it to this directory: `osmium cat ~/Downloads/changes.osc -o my_test_case.osm.xml`
+6.  Add a test case in `mod.rs`, following examples there
+
+## Viewing the OSM unit test inputs
+
+TODO

--- a/backend/src/osm_tests/deadend_with_barrier.osm.xml
+++ b/backend/src/osm_tests/deadend_with_barrier.osm.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="osmium/1.14.0">
+  <node id="-1" lat="55.7043636" lon="-0.1122805"/>
+  <node id="-2" lat="55.7043879" lon="-0.110359"/>
+  <node id="-4" lat="55.7043736" lon="-0.1114863"/>
+  <node id="-5" lat="55.7039909" lon="-0.1114861"/>
+  <node id="-6" lat="55.7040919" lon="-0.1114861">
+    <tag k="barrier" v="bollard"/>
+  </node>
+  <way id="-1">
+    <nd ref="-1"/>
+    <nd ref="-4"/>
+    <nd ref="-2"/>
+    <tag k="highway" v="residential"/>
+    <tag k="name" v="main"/>
+  </way>
+  <way id="-2">
+    <nd ref="-4"/>
+    <nd ref="-6"/>
+    <nd ref="-5"/>
+    <tag k="highway" v="residential"/>
+    <tag k="name" v="deadend"/>
+  </way>
+</osm>

--- a/backend/src/osm_tests/mod.rs
+++ b/backend/src/osm_tests/mod.rs
@@ -5,14 +5,32 @@ use crate::MapModel;
 #[test]
 fn test_deadend_with_barrier() {
     // There should be one modal filter on "deadend"
-    let map = load("deadend_with_barrier.osm.xml");
+    let map = load("deadend_with_barrier");
     assert_eq!(map.modal_filters.len(), 1);
     let road = map.get_r(*map.modal_filters.keys().next().unwrap());
     assert!(road.tags.is("name", "deadend"));
 }
 
+#[test]
+fn test_no_left_turn() {
+    let map = load("no_left_turn");
+    // Find the main intersection
+    let i = map
+        .intersections
+        .iter()
+        .find(|i| i.roads.len() > 1)
+        .unwrap();
+    // It should have one turn restriction from south to west
+    assert_eq!(i.turn_restrictions.len(), 1);
+    assert!(map.get_r(i.turn_restrictions[0].0).tags.is("name", "south"));
+    assert!(map.get_r(i.turn_restrictions[0].1).tags.is("name", "west"));
+}
+
 fn load(filename: &str) -> MapModel {
-    let path = format!("{}/src/osm_tests/{filename}", env!("CARGO_MANIFEST_DIR"));
+    let path = format!(
+        "{}/src/osm_tests/{filename}.osm.xml",
+        env!("CARGO_MANIFEST_DIR")
+    );
     let demand = None;
     // No test cases need this
     let boundary_wgs84 = MultiPolygon::new(Vec::new());

--- a/backend/src/osm_tests/mod.rs
+++ b/backend/src/osm_tests/mod.rs
@@ -1,0 +1,27 @@
+use geo::MultiPolygon;
+
+use crate::MapModel;
+
+#[test]
+fn test_deadend_with_barrier() {
+    // There should be one modal filter on "deadend"
+    let map = load("deadend_with_barrier.osm.xml");
+    assert_eq!(map.modal_filters.len(), 1);
+    let road = map.get_r(*map.modal_filters.keys().next().unwrap());
+    assert!(road.tags.is("name", "deadend"));
+}
+
+fn load(filename: &str) -> MapModel {
+    let path = format!("{}/src/osm_tests/{filename}", env!("CARGO_MANIFEST_DIR"));
+    let demand = None;
+    // No test cases need this
+    let boundary_wgs84 = MultiPolygon::new(Vec::new());
+    let study_area_name = None;
+    MapModel::new(
+        &std::fs::read(path).unwrap(),
+        boundary_wgs84,
+        study_area_name,
+        demand,
+    )
+    .unwrap()
+}

--- a/backend/src/osm_tests/no_left_turn.osm.xml
+++ b/backend/src/osm_tests/no_left_turn.osm.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6" generator="osmium/1.14.0">
+  <node id="-1" lat="55.7043636" lon="-0.1122805"/>
+  <node id="-2" lat="55.7043879" lon="-0.110359"/>
+  <node id="-4" lat="55.7043736" lon="-0.1114863"/>
+  <node id="-5" lat="55.7039909" lon="-0.1114861"/>
+  <node id="-7" lat="55.7046234" lon="-0.1114964"/>
+  <way id="-1">
+    <nd ref="-4"/>
+    <nd ref="-2"/>
+    <tag k="highway" v="residential"/>
+    <tag k="name" v="east"/>
+  </way>
+  <way id="-2">
+    <nd ref="-4"/>
+    <nd ref="-5"/>
+    <tag k="highway" v="residential"/>
+    <tag k="name" v="south"/>
+  </way>
+  <way id="-3">
+    <nd ref="-1"/>
+    <nd ref="-4"/>
+    <tag k="highway" v="residential"/>
+    <tag k="name" v="west"/>
+  </way>
+  <way id="-4">
+    <nd ref="-4"/>
+    <nd ref="-7"/>
+    <tag k="highway" v="residential"/>
+    <tag k="name" v="north"/>
+  </way>
+  <relation id="-1">
+    <member type="node" ref="-4" role="via"/>
+    <member type="way" ref="-2" role="from"/>
+    <member type="way" ref="-3" role="to"/>
+    <tag k="type" v="restriction"/>
+    <tag k="restriction" v="no_left_turn"/>
+  </relation>
+</osm>


### PR DESCRIPTION
For #6 and #101 and other reasons, it'd be very useful to test the LTN tool on really simple, minimal inputs. I'm proposing we:

1) Draw something simple in iD -- it's quite quick:
![image](https://github.com/user-attachments/assets/b42d62f5-1673-46d0-a500-6971b90eb3c4)
2) Write small bits of code to assert things, instead of a more cumbersome visual diff test (which just tries to check too many things at once)

If this approach looks good, I've got some cases related to detecting filters in #6 I'll turn into tests.