### PR TITLE
remove debug info when hovering over neighborhood

### DIFF
--- a/web/src/AutoBoundariesMode.svelte
+++ b/web/src/AutoBoundariesMode.svelte
@@ -140,15 +140,7 @@
         }}
         on:click={add}
         hoverCursor="pointer"
-      >
-        <Popup openOn="hover" let:props>
-          <p>Area: {props.area_km2.toFixed(1)} km²</p>
-          <p>
-            Borders roads = {props.touches_big_road}, railway = {props.touches_railway},
-            water = {props.touches_waterway}
-          </p>
-        </Popup>
-      </FillLayer>
+      />
 
       <LineLayer
         {...layerId("auto-boundaries-severances")}


### PR DESCRIPTION
Completes #25 

Autodetection of neighborhood boundaries isn't **perfect** (and never will be), but it's "good enough" that at this point it makes sense to focus on manual tools like #130 