### PR TITLE
Add missing loading screen when loading from url

### DIFF
--- a/web/src/title/TitleMode.svelte
+++ b/web/src/title/TitleMode.svelte
@@ -23,6 +23,7 @@
       let params = new URLSearchParams(window.location.search);
       let loadProject = params.get("project");
       if (loadProject) {
+        loading = `Loading project ${loadProject}`;
         loadFromLocalStorage(loadProject);
       }
     } else {


### PR DESCRIPTION
FIXES #117 

This is also responsible for the loading screen after creating a new CNT project, since the CNT project redirects you from ltn/cnt.html -> ltn/index.html.

**before:**


https://github.com/user-attachments/assets/3b846510-2c67-4cfd-9ed8-c7b9b0f0cadd



**after:**

https://github.com/user-attachments/assets/1fb9d9dd-ff06-44b0-94f2-eb356efae1ef

I still think the relationship between ltn/cnt.html and ltn/index.html could be made clearer, but this is a quick fix that improves thing in any case.