### PR TITLE
Redirect was broken when project name contained `#`

### DIFF
--- a/web/src/CntChooseArea.svelte
+++ b/web/src/CntChooseArea.svelte
@@ -78,7 +78,7 @@
         }),
       );
 
-      window.location.href = `index.html?project=${project}`;
+      window.location.href = `index.html?project=${encodeURIComponent(project)}`;
       return;
     }
   }


### PR DESCRIPTION
**before**:

https://github.com/user-attachments/assets/9c06c50a-d791-4900-8225-60177483e96c

**after**:

https://github.com/user-attachments/assets/3fd5318a-5ca5-407e-b734-b2933709a626

Note: this is a separate branch from #139, so there's no loading screen shown during the 5s loading period in the successful "after" video.


