### PR TITLE
Fix #149 for editing auto boundaries

### DIFF
--- a/web/src/SetBoundaryMode.svelte
+++ b/web/src/SetBoundaryMode.svelte
@@ -24,7 +24,9 @@
       // version of this tool, or an auto-generated boundary. Just
       // "backfill" by using the full geometry as freehand points.
       // Editing will be very painful in practice, but it won't break.
-      $waypoints = existing.geometry.coordinates[0].slice(1).map((point) => {
+      // Note the second polygon ring is used, because the boundary is expressed as
+      // "everywhere" minus a hole for the boundary, to achieve the fade-outside effect.
+      $waypoints = existing.geometry.coordinates[1].slice(1).map((point) => {
         return { point: gjPosition(point), snapped: false };
       });
     }


### PR DESCRIPTION
After fix:
![image](https://github.com/user-attachments/assets/e1a6b7c2-1d48-430f-ba94-95001f143185)

See `invert_study_area_boundary` in Rust for how this feature is made in the first place.

It'd still be useful to reduce the waypoints to make this sanely editable. I've been meaning to write the same thing for NPW. Given the full desired geometry, come up with minimal waypoints that achieve the same thing.