### PR TITLE
Make the *current* breadcrumb stand out

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -264,4 +264,9 @@
     margin-right: -32px;
     margin-left: -16px;
   }
+  :global(.pico nav[aria-label="breadcrumb"] ul li:last-child) {
+    font-size: 110%;
+    font-weight: bold;
+    text-decoration: underline;
+  }
 </style>


### PR DESCRIPTION
Just a cute little UI flourish that helps establish where you *are* in the breadcrumb. This might be especially effective for red/green color blind people like me for which the current "link" colored text does little to differentiate.

https://github.com/user-attachments/assets/44f9a0c8-9f70-43d7-96a9-6b94f0919444


