### PR TITLE
Stop displaying severances in the auto boundaries mode. #145

### DIFF
--- a/backend/src/auto_boundaries.rs
+++ b/backend/src/auto_boundaries.rs
@@ -28,29 +28,16 @@ impl MapModel {
                     "tertiary_link",
                 ],
             ) {
-                let mut f = self.mercator.to_wgs84_gj(&road.linestring);
-                // TODO Important to distinguish, or just debugging?
-                f.set_property("kind", "road severance");
-                features.push(f);
-
                 severances.push(road.linestring.clone());
                 road_severances.push(road.linestring.clone());
             }
         }
 
         for linestring in &self.railways {
-            let mut f = self.mercator.to_wgs84_gj(linestring);
-            f.set_property("kind", "railway severance");
-            features.push(f);
-
             severances.push(linestring.clone());
         }
 
         for linestring in &self.waterways {
-            let mut f = self.mercator.to_wgs84_gj(linestring);
-            f.set_property("kind", "waterway severance");
-            features.push(f);
-
             severances.push(linestring.clone());
         }
 
@@ -105,14 +92,7 @@ impl GeneratedBoundary {
     pub fn to_feature(&self, map: &MapModel) -> Feature {
         let mut projected = self.clone();
         map.mercator.to_wgs84_in_place(&mut projected.geometry);
-        let mut feature =
-            geojson::ser::to_feature(projected).expect("should have no unserializable fields");
-        let props = feature
-            .properties
-            .as_mut()
-            .expect("GeneratedBoundary always has properties");
-        props.insert("kind".to_string(), "area".into());
-        feature
+        geojson::ser::to_feature(projected).expect("should have no unserializable fields")
     }
 }
 

--- a/web/src/AutoBoundariesMode.svelte
+++ b/web/src/AutoBoundariesMode.svelte
@@ -8,7 +8,7 @@
     type LayerClickInfo,
   } from "svelte-maplibre";
   import { downloadGeneratedFile } from "svelte-utils";
-  import { isLine, isPolygon, makeRamp, Popup } from "svelte-utils/map";
+  import { makeRamp, Popup } from "svelte-utils/map";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
   import BackButton from "./BackButton.svelte";
   import { layerId, Link } from "./common";
@@ -72,7 +72,6 @@
   ): ExpressionSpecification {
     let x: ExpressionSpecification = [
       "all",
-      isPolygon,
       [">=", ["get", "area_km2"], minArea],
     ];
     if (removeNonRoad) {
@@ -135,16 +134,6 @@
 
   <div slot="map">
     <GeoJSON data={gj} generateId>
-      <LineLayer
-        {...layerId("auto-boundaries-severances")}
-        filter={isLine}
-        manageHoverState
-        paint={{
-          "line-color": hoverStateFilter("black", "red"),
-          "line-width": 3,
-        }}
-      />
-
       <FillLayer
         {...layerId("neighbourhood-boundaries", false)}
         filter={makeFilter(minArea, removeNonRoad)}
@@ -226,6 +215,15 @@
           {props.area_km2.toFixed(1)} km²
         </Popup>
       </FillLayer>
+
+      <LineLayer
+        {...layerId("neighbourhood-boundaries-outline", false)}
+        filter={makeFilter(minArea, removeNonRoad)}
+        paint={{
+          "line-color": "black",
+          "line-width": 1,
+        }}
+      />
     </GeoJSON>
   </div>
 </SplitComponent>

--- a/web/src/common/zorder.ts
+++ b/web/src/common/zorder.ts
@@ -85,6 +85,8 @@ const layerZorder = [
 
   streets("Ferry line"),
 
+  "neighbourhood-boundaries-outline",
+
   "debug-borders",
   "debug-filters",
 
@@ -142,9 +144,6 @@ const layerZorder = [
   // These're outside the neighbourhood-boundary, but don't fade them
   "border-arrows",
   "border-arrow-outlines",
-
-  "auto-boundaries-areas",
-  "auto-boundaries-severances",
 
   "freehand-line",
 


### PR DESCRIPTION
Before, severances are thick black lines that turn red when you hover on them. This was more intended for debug/development; they're confusing to the end user.
![image](https://github.com/user-attachments/assets/9a7b8c2e-6acf-4f7e-9a4f-eaaf640df917)

After, we just show a thin outline around the clickable boundaries:
![image](https://github.com/user-attachments/assets/a2b66ca0-ae0f-4882-96d5-a6baacdff967)

The holes in some boundaries due to ponds still looks odd, but that's something we can fix later.