### PR TITLE
Hide filters when zoomed out - it's too cluttered.

### DIFF
--- a/web/src/layers/ModalFilterLayer.svelte
+++ b/web/src/layers/ModalFilterLayer.svelte
@@ -4,6 +4,7 @@
   import { layerId } from "../common";
   import { backend, mutationCounter } from "../stores";
 
+  let minzoom = 13;
   // TODO Runes would make this so nicer. The > 0 part is a hack...
   $: gj =
     $mutationCounter > 0 ? $backend!.renderModalFilters() : emptyGeojson();
@@ -13,6 +14,7 @@
   <SymbolLayer
     {...layerId("modal-filters")}
     filter={["!=", ["get", "filter_kind"], "diagonal_filter"]}
+    {minzoom}
     layout={{
       "icon-image": ["get", "filter_kind"],
       "icon-rotate": ["get", "angle"],
@@ -29,6 +31,7 @@
   <SymbolLayer
     {...layerId("intersection-filters")}
     filter={["==", ["get", "filter_kind"], "diagonal_filter"]}
+    {minzoom}
     layout={{
       "icon-image": "diagonal_filter",
       "icon-rotate": ["get", "angle", ["get", "filter"]],


### PR DESCRIPTION
FIX https://github.com/a-b-street/ltn/issues/78

There's probably something fancier we could do, but this was easy and solves the worst of it.

**before:**


https://github.com/user-attachments/assets/6347c468-8ade-438f-b652-32a433fe2798



**after:**

https://github.com/user-attachments/assets/5a8f0f80-dd83-49ee-a96e-7f5e516ad04f


