### PR TITLE
Speed up boundary stats

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -38,6 +38,11 @@ petgraph = "0.7.1"
 criterion = "0.5.1"
 approx = "0.5.1"
 
+
+[[bench]]
+name = "boundary_stats"
+harness = false
+
 [[bench]]
 name = "build_map_model"
 harness = false

--- a/backend/benches/build_neighbourhood.rs
+++ b/backend/benches/build_neighbourhood.rs
@@ -8,7 +8,7 @@ fn benchmark_build_neighbourhood(c: &mut Criterion) {
         NeighbourhoodFixture::BRISTOL_WEST,
         NeighbourhoodFixture::STRASBOURG,
     ] {
-        let (neighbourhood_stats, map) = neighbourhood.neighbourhood_params().unwrap();
+        let (neighbourhood_boundary, map) = neighbourhood.neighbourhood_params().unwrap();
         let edit_perimeter_roads = false;
         c.bench_function(
             &format!(
@@ -17,9 +17,12 @@ fn benchmark_build_neighbourhood(c: &mut Criterion) {
             ),
             |b| {
                 b.iter(|| {
-                    let neighbourhood =
-                        Neighbourhood::new(&map, neighbourhood_stats.clone(), edit_perimeter_roads)
-                            .unwrap();
+                    let neighbourhood = Neighbourhood::new(
+                        &map,
+                        neighbourhood_boundary.clone(),
+                        edit_perimeter_roads,
+                    )
+                    .unwrap();
                     black_box(neighbourhood);
                 });
             },

--- a/backend/src/boundary_stats.rs
+++ b/backend/src/boundary_stats.rs
@@ -22,8 +22,8 @@ impl BoundaryStats {
         let mut simd = 0.0;
         if let Some(population_zones) = population_zones {
             for population_zone in population_zones {
-                if population_zone.geometry.intersects(polygon) {
-                    let overlap = polygon.intersection(&population_zone.geometry);
+                let overlap = polygon.intersection(&population_zone.geometry);
+                if overlap.unsigned_area() > 0.0 {
                     let overlap_ratio = overlap.unsigned_area() / area_meters;
                     simd += overlap_ratio * population_zone.imd_percentile as f64
                 }

--- a/backend/src/boundary_stats.rs
+++ b/backend/src/boundary_stats.rs
@@ -22,8 +22,8 @@ impl BoundaryStats {
         let mut simd = 0.0;
         if let Some(population_zones) = population_zones {
             for population_zone in population_zones {
-                let overlap = polygon.intersection(&population_zone.geometry);
-                if overlap.unsigned_area() > 0.0 {
+                if population_zone.geometry.intersects(polygon) {
+                    let overlap = polygon.intersection(&population_zone.geometry);
                     let overlap_ratio = overlap.unsigned_area() / area_meters;
                     simd += overlap_ratio * population_zone.imd_percentile as f64
                 }

--- a/backend/src/map_model.rs
+++ b/backend/src/map_model.rs
@@ -1,4 +1,4 @@
-use crate::boundary_stats::PopulationZone;
+use crate::boundary_stats::{PopulationZone, PreparedPopulationZone};
 use crate::geo_helpers::{
     angle_of_pt_on_line, bearing_from_endpoint, buffer_aabb, diagonal_bearing,
     invert_multi_polygon, limit_angle, linestring_intersection,
@@ -57,7 +57,7 @@ pub struct MapModel {
     pub redo_queue: Vec<Command>,
     pub boundaries: BTreeMap<String, NeighbourhoodBoundary>,
 
-    pub population_zones: Option<Vec<PopulationZone>>,
+    pub population_zones: Option<Vec<PreparedPopulationZone>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize)]

--- a/backend/src/neighbourhood.rs
+++ b/backend/src/neighbourhood.rs
@@ -9,7 +9,7 @@ use geojson::{Feature, FeatureCollection};
 use serde::{Deserialize, Serialize};
 use web_time::Instant;
 
-use crate::boundary_stats::{BoundaryStats, PopulationZone};
+use crate::boundary_stats::{BoundaryStats, PreparedPopulationZone};
 use crate::geo_helpers::{
     aabb, angle_of_line, buffer_aabb, clip_linestring_to_polygon, euclidean_destination, make_arrow,
 };
@@ -103,7 +103,7 @@ impl NeighbourhoodDefinition {
 impl NeighbourhoodBoundary {
     pub fn new(
         definition: NeighbourhoodDefinition,
-        population_zones: Option<&[PopulationZone]>,
+        population_zones: Option<&[PreparedPopulationZone]>,
     ) -> Self {
         let boundary_stats = BoundaryStats::new(&definition.geometry, population_zones);
         Self {


### PR DESCRIPTION
Followup to https://github.com/a-b-street/ltn/pull/166#discussion_r1966478092, to speed up the calculation using a prepared geometry.

```
build stats: LAD_Dundee City
                        time:   [1.8475 ms 1.8544 ms 1.8629 ms]
                        change: [-29.968% -29.750% -29.471%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Feel free to squash these commits (or at least the Temporary/Revert ones)
