### PR TITLE
buffer neighbourhood stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,6 @@ dependencies = [
  "fast_paths",
  "geo",
  "geojson",
- "i_float",
  "i_overlay",
  "itertools 0.14.0",
  "log",
@@ -422,7 +421,6 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 [[package]]
 name = "geo"
 version = "0.29.3"
-source = "git+https://github.com/georust/geo#686363b3e46f4167e38fab307dbe5b10820485ec"
 dependencies = [
  "earcutr",
  "float_next_after",
@@ -439,7 +437,6 @@ dependencies = [
 [[package]]
 name = "geo-types"
 version = "0.7.15"
-source = "git+https://github.com/georust/geo#686363b3e46f4167e38fab307dbe5b10820485ec"
 dependencies = [
  "approx",
  "num-traits",
@@ -537,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "i_float"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775f9961a8d2f879725da8aff789bb20a3ddf297473e0c90af75e69313919490"
+checksum = "85df3a416829bb955fdc2416c7b73680c8dcea8d731f2c7aa23e1042fe1b8343"
 dependencies = [
  "serde",
 ]
@@ -552,9 +549,9 @@ checksum = "347c253b4748a1a28baf94c9ce133b6b166f08573157e05afe718812bc599fcd"
 
 [[package]]
 name = "i_overlay"
-version = "1.9.4"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01882ce5ed786bf6e8f5167f171a4026cd129ce17d9ff5cbf1e6749b98628ece"
+checksum = "b147cb6b642e3e84f7c6a4aec505a1dc9a5834b75c6f106be1d6884db45c1fcd"
 dependencies = [
  "i_float",
  "i_key_sort",
@@ -565,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "i_shape"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27dbe9e5238d6b9c694c08415bf00fb370b089949bd818ab01f41f8927b8774c"
+checksum = "0a38f5a42678726718ff924f6d4a0e79b129776aeed298f71de4ceedbd091bce"
 dependencies = [
  "i_float",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 [[package]]
 name = "geo"
 version = "0.29.3"
+source = "git+https://github.com/georust/geo?branch=mkirk%2Fgeo-buffer#3e0f514759936857e373c881d70902e3d3afbc6c"
 dependencies = [
  "earcutr",
  "float_next_after",
@@ -437,6 +438,7 @@ dependencies = [
 [[package]]
 name = "geo-types"
 version = "0.7.15"
+source = "git+https://github.com/georust/geo#c1f8131c4636c581c255a7762aa317354789decd"
 dependencies = [
  "approx",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ utils = { git = "https://github.com/a-b-street/utils", features = ["serde"] }
 opt-level = 3
 
 [patch.crates-io]
-geo = { git = "https://github.com/georust/geo" }
-geo-types = { git = "https://github.com/georust/geo" }
+# geo = { git = "https://github.com/georust/geo" }
+geo = { path = "../../georust/geo/geo" }
+# geo-types = { git = "https://github.com/georust/geo" }
+geo-types = { path = "../../georust/geo/geo-types" }
 
+[patch."https://github.com/georust/geo"]
+geo = { path = "../../georust/geo/geo" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [workspace.dependencies]
 anyhow = "1.0.82"
 bincode = "1.3.3"
-geo = { git = "https://github.com/georust/geo" }
+geo = { git = "https://github.com/georust/geo", branch="mkirk/geo-buffer" }
 geojson = { git = "https://github.com/georust/geojson", features = ["geo-types"] }
 serde = "1.0.188"
 utils = { git = "https://github.com/a-b-street/utils", features = ["serde"] }
@@ -23,10 +23,6 @@ utils = { git = "https://github.com/a-b-street/utils", features = ["serde"] }
 opt-level = 3
 
 [patch.crates-io]
-# geo = { git = "https://github.com/georust/geo" }
-geo = { path = "../../georust/geo/geo" }
-# geo-types = { git = "https://github.com/georust/geo" }
-geo-types = { path = "../../georust/geo/geo-types" }
-
-[patch."https://github.com/georust/geo"]
-geo = { path = "../../georust/geo/geo" }
+geo = { git = "https://github.com/georust/geo", branch="mkirk/geo-buffer" }
+#geo = { path = "../../georust/geo/geo" }
+geo-types = { git = "https://github.com/georust/geo" }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -18,8 +18,7 @@ geojson.workspace = true
 # Note: i_overlay doesn't follow semver, and only guarantees non-breaking across patch versions.
 # https://github.com/iShape-Rust/iOverlay?tab=readme-ov-file#versioning-policy
 # So we pin to a minor version.
-i_overlay = { version = ">=1.9.4,<1.10.0", default-features = false }
-i_float = "1.3.1"
+i_overlay = { version = ">=2.0.0,<2.1.0", default-features = false }
 log = "0.4.20"
 nanorand = { version = "0.7.0", default-features = false, features = ["wyrand"] }
 osm-reader = { git = "https://github.com/a-b-street/osm-reader" }

--- a/backend/benches/boundary_stats.rs
+++ b/backend/benches/boundary_stats.rs
@@ -11,7 +11,11 @@ fn benchmark_build_map_model(c: &mut Criterion) {
             200
         );
         c.bench_function(
-            &format!("build stats: {name}", name = fixture.study_area_name),
+            &format!(
+                "build stats: {neighbourhood} in {study_area}",
+                neighbourhood = fixture.neighbourhood_name,
+                study_area = fixture.study_area_name
+            ),
             |b| {
                 b.iter(|| {
                     let stats = BoundaryStats::new(
@@ -19,6 +23,19 @@ fn benchmark_build_map_model(c: &mut Criterion) {
                         map.context_data.as_ref(),
                     );
                     black_box(stats);
+                });
+            },
+        );
+        c.bench_function(
+            &format!(
+                "generate auto boundaries (and stats) for all of {study_area}",
+                study_area = fixture.study_area_name
+            ),
+            |b| {
+                b.iter(|| {
+                    let boundaries = map.render_auto_boundaries();
+                    assert_eq!(boundaries.features.len(), 1102);
+                    black_box(boundaries);
                 });
             },
         );

--- a/backend/src/boundary_stats.rs
+++ b/backend/src/boundary_stats.rs
@@ -57,7 +57,7 @@ impl BoundaryStats {
             // Conclusion: To count incidents on the perimeter, we should buffer a bit more than 1/2
             // the expected road width.
             let buffer_meters = 10.0;
-            let style = OutlineStyle::new(buffer_meters).line_join(LineJoin::Miter(0.1));
+            let style = OutlineStyle::new(buffer_meters).line_join(LineJoin::Round(0.1));
             let buffered_polygon = polygon.buffer_with_style(style);
             let polygon_prepared = PreparedGeometry::from(buffered_polygon.clone());
             for pt in &context_data.stats19_collisions {

--- a/backend/src/boundary_stats.rs
+++ b/backend/src/boundary_stats.rs
@@ -43,7 +43,7 @@ impl BoundaryStats {
             // that erring on "too much" is likely to err the results less than "too little"
             // (including a few extra beyond the perimeter vs. clipping off the many which are on the perimeter)
             let buffer_meters = 10.0;
-            let style = OutlineStyle::new(buffer_meters).line_join(LineJoin::Bevel);
+            let style = OutlineStyle::new(buffer_meters).line_join(LineJoin::Round(0.1));
             let buffered_polygon = polygon.buffer_with_style(style);
             let polygon_prepared = PreparedGeometry::from(buffered_polygon.clone());
             for pt in &context_data.stats19_collisions {

--- a/backend/src/boundary_stats.rs
+++ b/backend/src/boundary_stats.rs
@@ -43,7 +43,7 @@ impl BoundaryStats {
             // that erring on "too much" is likely to err the results less than "too little"
             // (including a few extra beyond the perimeter vs. clipping off the many which are on the perimeter)
             let buffer_meters = 10.0;
-            let style = OutlineStyle::new(buffer_meters).line_join(LineJoin::Round(0.1));
+            let style = OutlineStyle::new(buffer_meters).line_join(LineJoin::Miter(0.1));
             let buffered_polygon = polygon.buffer_with_style(style);
             let polygon_prepared = PreparedGeometry::from(buffered_polygon.clone());
             for pt in &context_data.stats19_collisions {

--- a/backend/src/boundary_stats.rs
+++ b/backend/src/boundary_stats.rs
@@ -35,13 +35,27 @@ impl BoundaryStats {
                 }
             }
 
-            // TODO: Review this tolerance - we want to encompass any incidents "on" the road.
-            // So in theory, if our road LineString's are center-lines, we want at least half a
-            // road-width beyond. But we can't reasonably know each road width for this calculation,
-            // so a better baseline would be "a little larger than it would need to be".
-            // Since so many incidents are likely to occur *on* the perimeter road, my intuition is
-            // that erring on "too much" is likely to err the results less than "too little"
-            // (including a few extra beyond the perimeter vs. clipping off the many which are on the perimeter)
+            // Counting incidents in a given neighbourhood, we want to include incidents that happen
+            // *on* the perimeter road, not just the interior.
+            //
+            // Our road LineString's are center-lines, so to count incidents *on* the perimeter,
+            // conceptually we need a buffer at least half a road-width beyond our perimeter.
+            //
+            // To make the analysis reasonable, we only provide one uniform buffer amount.
+            // We can't reasonably buffer each raod segment based on the "actual" road width of that
+            // segment.
+            //
+            // So how wide should we buffer?
+            //
+            // Extending beyond the perimeter road should include relatively fewer "extra"
+            // incidents, where as clipping off part of the perimeter road itself (by buffering too small)
+            // will more likely clip off relatively more incidents.
+            //
+            // Erring towards "a bit too big" will give more accurate results than
+            // "a bit too small".
+            //
+            // Conclusion: To count incidents on the perimeter, we should buffer a bit more than 1/2
+            // the expected road width.
             let buffer_meters = 10.0;
             let style = OutlineStyle::new(buffer_meters).line_join(LineJoin::Miter(0.1));
             let buffered_polygon = polygon.buffer_with_style(style);

--- a/backend/src/boundary_stats.rs
+++ b/backend/src/boundary_stats.rs
@@ -57,7 +57,7 @@ impl BoundaryStats {
             // Conclusion: To count incidents on the perimeter, we should buffer a bit more than 1/2
             // the expected road width.
             let buffer_meters = 10.0;
-            let style = OutlineStyle::new(buffer_meters).line_join(LineJoin::Round(0.1));
+            let style = OutlineStyle::new(buffer_meters).line_join(LineJoin::Bevel);
             let buffered_polygon = polygon.buffer_with_style(style);
             let polygon_prepared = PreparedGeometry::from(buffered_polygon.clone());
             for pt in &context_data.stats19_collisions {

--- a/backend/src/geo_helpers/slice_nearest_boundary.rs
+++ b/backend/src/geo_helpers/slice_nearest_boundary.rs
@@ -1,6 +1,6 @@
 use geo::{
-    coord, Closest, ClosestPoint, Distance, Euclidean, FrechetDistance, HasDimensions, LineString,
-    Point, Polygon,
+    coord, line_measures::FrechetDistance, Closest, ClosestPoint, Distance, Euclidean,
+    HasDimensions, LineString, Point, Polygon,
 };
 use std::cmp::Ordering;
 
@@ -31,13 +31,13 @@ impl SliceNearestFrechetBoundary for Polygon {
         // Of the two parts, the one with the lowest frechet_distance represents the best
         // candidate for its corresponding boundary.
         let (forwards_half, backwards_half) = self.split_boundary_nearest_endpoints(closest_to);
-        let forwards_frechet = forwards_half.frechet_distance(closest_to);
+        let forwards_frechet = Euclidean.frechet_distance(&forwards_half, &closest_to);
 
         // The second half of the polygon begins where the first half ends, so we
         // need to reverse `closest_to` to get an accurate (minimal) distance measure
         let mut backwards_closest_to = closest_to.clone();
         backwards_closest_to.0.reverse();
-        let backwards_frechet = backwards_half.frechet_distance(&backwards_closest_to);
+        let backwards_frechet = Euclidean.frechet_distance(&backwards_half, &backwards_closest_to);
 
         if forwards_frechet < backwards_frechet {
             (forwards_half, forwards_frechet)

--- a/web/src/AutoBoundariesMode.svelte
+++ b/web/src/AutoBoundariesMode.svelte
@@ -204,7 +204,7 @@
           {:else if selectedPrioritization == "stats19"}
             <b>
               Density of pedestrian and cyclist collisions (collisions per
-              square meter):
+              square kilometer):
             </b>
             {(props.number_stats19_collisions / props.area_km2).toFixed(1)}
           {/if}

--- a/web/src/PickNeighbourhoodMode.svelte
+++ b/web/src/PickNeighbourhoodMode.svelte
@@ -328,7 +328,7 @@
           {:else if selectedPrioritization == "stats19"}
             <b>
               Density of pedestrian and cyclist collisions (collisions per
-              square meter):
+              square kilometer):
             </b>
             {(props.number_stats19_collisions / props.area_km2).toFixed(1)}
           {/if}


### PR DESCRIPTION
It's about 10-15% slower to include buffering.  But it does significantly affect the results. Do you think it's worth it?

Personally I think we should. I think there is some performance work I can (would like to) do on the geo side to speed this up a bit, plus we can always pull out the buffering in the worst case if it proves intolerably slow.

**before:**

<img width="2416" alt="Screenshot 2025-02-25 at 16 06 29" src="https://github.com/user-attachments/assets/fb07b7fa-61a6-4b07-a015-b58c5e28517f" />

**after:**

<img width="1264" alt="Screenshot 2025-02-25 at 16 08 29" src="https://github.com/user-attachments/assets/dd2cb673-cf74-4634-bbae-3f759d72f859" />


## autogenerated screen

Sorry, it's hard to tell, but I'm hovering the same boundary.

**before:**

<img width="2416" alt="Screenshot 2025-02-25 at 16 07 03" src="https://github.com/user-attachments/assets/b98d3131-d799-4b67-b470-cce8051c9485" />

**after:**

<img width="581" alt="Screenshot 2025-02-25 at 16 10 20" src="https://github.com/user-attachments/assets/4ff43fe8-900b-43fa-8aaf-a02d34925319" />

