### PR TITLE
Speed up BoundaryStats by preparing boundary polygon

### DIFF
--- a/backend/src/boundary_stats.rs
+++ b/backend/src/boundary_stats.rs
@@ -17,6 +17,8 @@ impl BoundaryStats {
         let mut simd = 0.0;
         let mut number_stats19_collisions = 0;
         if let Some(context_data) = context_data {
+            let prepared_polygon = PreparedGeometry::from(polygon);
+
             // TODO: review this methodology
             // area proportional accumulation:
             // If  3/4 the boundary is in a zone with simd 100:   0.75 * 100 = 75
@@ -26,7 +28,7 @@ impl BoundaryStats {
             for population_zone in &context_data.population_zones {
                 if population_zone
                     .prepared_geometry
-                    .relate(polygon)
+                    .relate(&prepared_polygon)
                     .is_intersects()
                 {
                     let overlap = polygon.intersection(&population_zone.population_zone.geometry);
@@ -59,9 +61,9 @@ impl BoundaryStats {
             let buffer_meters = 10.0;
             let style = OutlineStyle::new(buffer_meters).line_join(LineJoin::Bevel);
             let buffered_polygon = polygon.buffer_with_style(style);
-            let polygon_prepared = PreparedGeometry::from(buffered_polygon.clone());
+            let prepared_buffered_polygon = PreparedGeometry::from(&buffered_polygon);
             for pt in &context_data.stats19_collisions {
-                if polygon_prepared.relate(pt).is_contains() {
+                if prepared_buffered_polygon.relate(pt).is_contains() {
                     number_stats19_collisions += 1;
                 }
             }


### PR DESCRIPTION
Previously we were only preparing the population zones, not the boundary polygon itself.

But since we check *every* zone against the boundary, it makes sense to prepare the boundary.

Also a smaller change: Though we were correctly using PreparedGeometry for the Stats19 point check, we don't need to clone that geometry.

== BENCHMARKS
```
build stats: Hilltown in LAD_Dundee City
                        time:   [1.3602 ms 1.3667 ms 1.3746 ms]
                        change: [-43.356% -42.906% -42.448%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking generate auto boundaries (and stats) for all of LAD_Dundee City: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 46.4s, or reduce sample count to 10.
generate auto boundaries (and stats) for all of LAD_Dundee City
                        time:   [458.47 ms 458.82 ms 459.21 ms]
                        change: [-19.155% -18.821% -18.503%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
```