### PR TITLE
Disable 3D buildings

### DIFF
--- a/web/src/About.svelte
+++ b/web/src/About.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Modal, notNull } from "svelte-utils";
+  import { Modal } from "svelte-utils";
   import { showAbout } from "./stores";
 </script>
 


### PR DESCRIPTION
Before, at high zoom, 3D building extrusions are a little visually noisy. I can't find a bad case right now, but sometimes the shadow even obscures roads that we're trying to color.
![image](https://github.com/user-attachments/assets/79a746aa-a216-4f12-b9a1-844f289bfa1d)

After, just use the flat 2D all the time:
![image](https://github.com/user-attachments/assets/aa5f4605-0918-4979-8392-b4b88b5d20dd)
