### PR TITLE
When two roads meet, draw the one with more shortcuts on top

### DIFF
--- a/web/src/layers/InteriorRoadLayer.svelte
+++ b/web/src/layers/InteriorRoadLayer.svelte
@@ -93,6 +93,9 @@
     "line-color": roadLineColor($roadStyle, gj.maxShortcuts),
     "line-opacity": hoverStateFilter(1.0, 0.5),
   }}
+  layout={{
+    "line-sort-key": ["get", "shortcuts"],
+  }}
   on:click={(e) =>
     interactive && onClickLine(e.detail.features[0], e.detail.event.lngLat)}
   manageHoverState={interactive}


### PR DESCRIPTION
Road center-lines meet at the same point, so when the lines are thickened in maplibre, the polygons overlap a bit.

Before, the lines are drawn in some arbitrary order (based on road IDs, just the order we scrape OSM data). White deadends with no shortcuts partly cover up red roads:
![image](https://github.com/user-attachments/assets/a08e1bc9-3890-4982-98bb-79ddeb921812)

After, it looks a little cleaner in some places:
![image](https://github.com/user-attachments/assets/a0cee2e2-4e26-4dd0-b087-30ca5161f721)
