### PR TITLE
update geo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 [[package]]
 name = "geo"
 version = "0.29.3"
-source = "git+https://github.com/georust/geo?branch=mkirk%2Fgeo-buffer#cf28bf54d6d855defaffa810753056242acb8b87"
+source = "git+https://github.com/georust/geo?branch=mkirk%2Fgeo-ltn#9286aa364bcaafb5c0732a300329a5fdccacc849"
 dependencies = [
  "earcutr",
  "float_next_after",
@@ -438,7 +438,7 @@ dependencies = [
 [[package]]
 name = "geo-types"
 version = "0.7.15"
-source = "git+https://github.com/georust/geo#c1f8131c4636c581c255a7762aa317354789decd"
+source = "git+https://github.com/georust/geo?branch=mkirk%2Fgeo-ltn#9286aa364bcaafb5c0732a300329a5fdccacc849"
 dependencies = [
  "approx",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [workspace.dependencies]
 anyhow = "1.0.82"
 bincode = "1.3.3"
-geo = { git = "https://github.com/georust/geo", branch="mkirk/geo-buffer" }
+geo = { git = "https://github.com/georust/geo", branch="mkirk/geo-ltn" }
 geojson = { git = "https://github.com/georust/geojson", features = ["geo-types"] }
 serde = "1.0.188"
 utils = { git = "https://github.com/a-b-street/utils", features = ["serde"] }
@@ -23,6 +23,6 @@ utils = { git = "https://github.com/a-b-street/utils", features = ["serde"] }
 opt-level = 3
 
 [patch.crates-io]
-geo = { git = "https://github.com/georust/geo", branch="mkirk/geo-buffer" }
+geo = { git = "https://github.com/georust/geo", branch="mkirk/geo-ltn" }
 #geo = { path = "../../georust/geo/geo" }
-geo-types = { git = "https://github.com/georust/geo" }
+geo-types = { git = "https://github.com/georust/geo", branch="mkirk/geo-ltn" }

--- a/backend/src/boundary_stats.rs
+++ b/backend/src/boundary_stats.rs
@@ -114,5 +114,5 @@ pub struct PopulationZone {
 
 pub struct PreparedPopulationZone {
     pub population_zone: PopulationZone,
-    pub prepared_geometry: PreparedGeometry<'static>,
+    pub prepared_geometry: PreparedGeometry<'static, MultiPolygon>,
 }

--- a/backend/src/create.rs
+++ b/backend/src/create.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use anyhow::Result;
-use geo::{Coord, LineInterpolatePoint, LineString, MultiPolygon, PreparedGeometry};
+use geo::line_measures::InterpolatableLine;
+use geo::{Coord, Euclidean, LineString, MultiPolygon, PreparedGeometry};
 use osm_reader::{NodeID, OsmID, RelationID, WayID};
 use petgraph::graphmap::UnGraphMap;
 use rstar::{primitives::GeomWithData, RTree};
@@ -360,7 +361,7 @@ fn apply_existing_filters(
             let pt = map
                 .get_r(r)
                 .linestring
-                .line_interpolate_point(percent)
+                .point_at_ratio_from_start(&Euclidean, percent)
                 .unwrap();
             map.add_modal_filter(pt.into(), Some(vec![r]), filter);
         }

--- a/backend/src/geo_helpers/mod.rs
+++ b/backend/src/geo_helpers/mod.rs
@@ -1,10 +1,10 @@
 mod slice_nearest_boundary;
 pub use slice_nearest_boundary::SliceNearestFrechetBoundary;
 
+use geo::line_measures::InterpolatableLine;
 use geo::{
     BooleanOps, BoundingRect, Contains, Coord, Distance, Euclidean, Intersects, Length, Line,
-    LineInterpolatePoint, LineIntersection, LineLocatePoint, LineString, MultiPolygon, Point,
-    Polygon, Rect, Validation,
+    LineIntersection, LineLocatePoint, LineString, MultiPolygon, Point, Polygon, Rect, Validation,
 };
 use rstar::AABB;
 use utils::LineSplit;
@@ -71,7 +71,7 @@ pub fn clip_linestring_to_polygon(linestring: &LineString, polygon: &Polygon) ->
                 continue;
             };
             // Is this piece inside the polygon or not? Check the midpoint
-            if let Some(midpt) = split.line_interpolate_point(0.5) {
+            if let Some(midpt) = split.point_at_ratio_from_start(&Euclidean, 0.5) {
                 if polygon.contains(&midpt) {
                     results.push(split);
                 }

--- a/backend/src/neighbourhood.rs
+++ b/backend/src/neighbourhood.rs
@@ -482,10 +482,10 @@ enum LineInPolygon {
 }
 
 // NOTE: polygon must be `valid` (no spikes!) to get reasonable results
-fn line_in_polygon(
+fn line_in_polygon<'a>(
     linestring: &LineString,
     polygon: &Polygon,
-    prepared_polygon: &PreparedGeometry,
+    prepared_polygon: &PreparedGeometry<'a, &'a Polygon>,
 ) -> LineInPolygon {
     let perimeter_likelihood = perimeter_likelihood(&linestring, polygon);
     // This is an arbitrary threshold - we could tune it if we're getting false positives/negatives

--- a/data_prep/scotland/src/bin/generate_prioritization.rs
+++ b/data_prep/scotland/src/bin/generate_prioritization.rs
@@ -91,7 +91,8 @@ impl PopulationZoneInput {
         Ok(population_zones)
     }
 
-    fn read_all_prepared_from_file() -> Result<Vec<(PreparedGeometry<'static>, Self)>> {
+    fn read_all_prepared_from_file() -> Result<Vec<(PreparedGeometry<'static, MultiPolygon>, Self)>>
+    {
         let iter = Self::read_all_from_file()?
             .into_iter()
             .map(|population_zone| {

--- a/data_prep/scotland/src/lib.rs
+++ b/data_prep/scotland/src/lib.rs
@@ -18,7 +18,8 @@ impl StudyArea {
         println!("Read {} study area boundaries", study_areas.len());
         Ok(study_areas)
     }
-    pub fn read_all_prepared_from_file() -> Result<Vec<(PreparedGeometry<'static>, Self)>> {
+    pub fn read_all_prepared_from_file(
+    ) -> Result<Vec<(PreparedGeometry<'static, MultiPolygon>, Self)>> {
         let iter = Self::read_all_from_file()?.into_iter().map(|study_area| {
             (
                 PreparedGeometry::from(study_area.geometry.clone()),


### PR DESCRIPTION
Note this includes the as-of-yet unmerged https://github.com/georust/geo/pull/1321 and https://github.com/georust/geo/pull/1322

Primarily this gets us a nice perf boost in the stats calculation:
  
    build stats: Hilltown in LAD_Dundee City
                            time:   [890.95 µs 894.88 µs 899.45 µs]
                            change: [-34.332% -34.080% -33.830%] (p = 0.00 < 0.05)
                            Performance has improved.
    
    generate auto boundaries (and stats) for all of LAD_Dundee City
                            time:   [192.06 ms 192.32 ms 192.67 ms]
                            change: [-61.269% -61.036% -60.823%] (p = 0.00 < 0.05)
                            Performance has improved.
    
And some modest wins elsewhere...
    
    build map_model: bristol
                            time:   [83.446 ms 83.560 ms 83.688 ms]
                            change: [-3.4679% -2.8247% -2.2423%] (p = 0.00 < 0.05)
                            Performance has improved.
