### PR TITLE
Fix routes incorrectly ending on a road with a modal filter

### DIFF
--- a/backend/src/map_model.rs
+++ b/backend/src/map_model.rs
@@ -158,6 +158,9 @@ impl Intersection {
             if to_road.id == from_road.id {
                 return None;
             }
+            if router_input.has_modal_filter(to_road.id) {
+                return None;
+            }
             if router_input
                 .turn_restrictions(self.id)
                 .contains(&(from_r, to_road.id))


### PR DESCRIPTION
Cici spotted quite a notable bug:
![image](https://github.com/user-attachments/assets/b958ff51-87b6-46bf-a595-7d2a12175f62)
An interior road right on the edge with a filter on it should not have any shortcuts! View shortcut mode reveals the problem is routes ending there:
![image](https://github.com/user-attachments/assets/e6ee4f86-94a4-4d9d-8c3d-767acc0ae9a9)

Previously, I think we got away with this because of https://github.com/a-b-street/ltn/blob/00fb50bbedf1cb37606a54de99a91398a85e4c3e/backend/src/route.rs#L63. Roads with filters weren't part of the CH graph at all. But the change to `(road, direction)` pairs and handling all roads connected to the start/end intersection somehow let this slip in.