### PR TITLE
Remove holes (lakes) from generated boundaries

### DIFF
--- a/backend/src/auto_boundaries.rs
+++ b/backend/src/auto_boundaries.rs
@@ -144,13 +144,16 @@ fn split_polygon(polygon: Polygon, linestrings: &Vec<LineString>) -> Vec<Polygon
 
     let splitters: Vec<_> = linestrings.iter().map(to_i_overlay_contour).collect();
     let shapes = shape.slice_by(&splitters, FillRule::NonZero);
-    shapes.into_iter().map(to_geo_polygon).collect()
-}
 
-fn to_geo_polygon(rings: Vec<Vec<[f64; 2]>>) -> Polygon {
-    let mut interiors: Vec<LineString> = rings.into_iter().map(to_geo_linestring).collect();
-    let exterior = interiors.remove(0);
-    Polygon::new(exterior, interiors)
+    shapes
+        .into_iter()
+        .map(|rings| {
+            let exterior = rings.into_iter().next().expect("shapes must be non-empty");
+            let exterior_line_string = to_geo_linestring(exterior);
+            // We ignore any interiors
+            Polygon::new(exterior_line_string, vec![])
+        })
+        .collect()
 }
 
 fn to_geo_linestring(pts: Vec<[f64; 2]>) -> LineString {


### PR DESCRIPTION
FIXES #145 (just the final bit)

I hadn't really considered this, but this actually has some (small) correctness implications for our prioritization aggregation:

**before:**
<img width="372" alt="Screenshot 2025-03-06 at 13 10 48" src="https://github.com/user-attachments/assets/fbdbf872-ca30-410c-99ba-47e1149d3e66" />

**after:**
<img width="389" alt="Screenshot 2025-03-06 at 13 13 50" src="https://github.com/user-attachments/assets/e8239594-9044-4e23-9d23-b20e6b375505" />
