### PR TITLE
Reconcile CNT vs. vanilla LTN landing pages

### DIFF
--- a/web/cnt.html
+++ b/web/cnt.html
@@ -8,10 +8,13 @@
   <body>
     <div id="app"></div>
     <script type="module">
-      import App from "./src/CntChooseArea.svelte";
+      import App from "./src/App.svelte";
 
       new App({
         target: document.getElementById("app"),
+        props: {
+          appFocus: "cnt",
+        },
       });
     </script>
   </body>

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,3 +1,7 @@
+<script context="module" lang="ts">
+  export type AppFocus = "global" | "cnt";
+</script>
+
 <script lang="ts">
   import onewayArrowUrl from "../assets/arrow.png?url";
   import logo from "../assets/logo.svg?url";
@@ -6,9 +10,9 @@
   import ContextualLayers from "./context/ContextualLayers.svelte";
   import "@picocss/pico/css/pico.conditional.jade.min.css";
   import initLtn from "backend";
-  import type { Map, StyleSpecification } from "maplibre-gl";
+  import type { LngLatBoundsLike, Map, StyleSpecification } from "maplibre-gl";
   import { init as initRouteSnapper } from "route-snapper-ts";
-  import { onMount } from "svelte";
+  import { onMount, setContext } from "svelte";
   import {
     FillLayer,
     GeoJSON,
@@ -92,6 +96,13 @@
     mapDiv.appendChild($mapContents);
   }
 
+  export let appFocus: AppFocus = "global";
+  setContext("appFocus", appFocus);
+
+  let initialBounds: LngLatBoundsLike | undefined = undefined;
+  if (appFocus == "cnt") {
+    initialBounds = [-8.943, 54.631, -0.901, 59.489];
+  }
   async function getStyle(
     basemap: string,
   ): Promise<StyleSpecification | string> {
@@ -115,139 +126,145 @@
 <div class="pico">
   <About />
 </div>
-<Layout>
-  <div slot="top" class="pico" style="display: flex">
-    <button class="outline" on:click={() => ($showAbout = true)}>
-      <img src={logo} style="height: 6vh;" alt="A/B Street logo" />
-    </button>
-    <Settings />
-    <span bind:this={topDiv} style="width: 100%" />
-  </div>
-  <div class="pico" slot="left">
-    <div bind:this={sidebarDiv} />
-
-    <hr />
-
-    {#if $backend}
-      <button class="secondary" on:click={zoomToFit}>
-        Zoom to fit study area
+<div class="app-focus-{appFocus}">
+  <Layout>
+    <div slot="top" class="pico" style="display: flex">
+      <button class="outline" on:click={() => ($showAbout = true)}>
+        <img src={logo} style="height: 6vh;" alt="A/B Street logo" />
       </button>
-      <StreetView map={notNull($mapStore)} maptilerBasemap={$maptilerBasemap} />
-    {/if}
-  </div>
-  <div slot="main" style="position: relative; width: 100%; height: 100%;">
-    {#await getStyle($maptilerBasemap) then style}
-      <MapLibre
-        {style}
-        hash
-        bind:map
-        on:error={(e) => {
-          // @ts-expect-error ErrorEvent isn't exported
-          console.log(e.detail.error);
-        }}
-        images={[
-          {
-            id: "walk_cycle_only",
-            url: `${import.meta.env.BASE_URL}/filters/walk_cycle_only_icon.gif`,
-          },
-          {
-            id: "no_entry",
-            url: `${import.meta.env.BASE_URL}/filters/no_entry_icon.gif`,
-          },
-          {
-            id: "bus_gate",
-            url: `${import.meta.env.BASE_URL}/filters/bus_gate_icon.gif`,
-          },
-          {
-            id: "school_street",
-            url: `${import.meta.env.BASE_URL}/filters/school_street_icon.gif`,
-          },
-          {
-            id: "diagonal_filter",
-            url: `${import.meta.env.BASE_URL}/filters/diagonal_filter_icon.png`,
-          },
-          {
-            id: "no_straight_turn",
-            url: `${import.meta.env.BASE_URL}/filters/no_straight_turn.png`,
-          },
-          {
-            id: "no_left_turn",
-            url: `${import.meta.env.BASE_URL}/filters/no_left_turn.png`,
-          },
-          {
-            id: "no_right_turn",
-            url: `${import.meta.env.BASE_URL}/filters/no_right_turn.png`,
-          },
-          {
-            id: "no_u_left_to_right_turn",
-            url: `${import.meta.env.BASE_URL}/filters/no_u_left_to_right_turn.png`,
-          },
-          {
-            id: "no_u_right_to_left_turn",
-            url: `${import.meta.env.BASE_URL}/filters/no_u_right_to_left_turn.png`,
-          },
-          {
-            id: "oneway_arrow",
-            url: onewayArrowUrl,
-          },
-          {
-            id: "national_rail",
-            url: nationalRailUrl,
-          },
-        ]}
-      >
-        <NavigationControl />
-        <ScaleControl />
-        <Geocoder {map} apiKey={maptilerApiKey} country={undefined} />
-        {#if $projectName.startsWith("ltn_cnt/")}
-          <ContextualLayers />
-        {/if}
+      <Settings />
+      <span bind:this={topDiv} style="width: 100%" />
+    </div>
+    <div class="pico" slot="left">
+      <div bind:this={sidebarDiv} />
 
-        <div bind:this={mapDiv} />
+      <hr />
 
-        {#if $mode.mode == "title"}
-          <TitleMode {wasmReady} firstLoad={$mode.firstLoad} />
-        {:else if $mode.mode == "new-project"}
-          <NewProjectMode />
-        {/if}
-        {#if $backend}
-          <GeoJSON data={$backend.getInvertedBoundary()}>
-            <FillLayer
-              {...layerId("boundary")}
-              paint={{ "fill-color": "black", "fill-opacity": 0.3 }}
-            />
-          </GeoJSON>
-          {#if $mode.mode == "pick-neighbourhood"}
-            <PickNeighbourhoodMode />
-          {:else if $mode.mode == "set-boundary"}
-            <SetBoundaryMode name={$mode.name} existing={$mode.existing} />
-          {:else if $mode.mode == "auto-boundaries"}
-            <AutoBoundariesMode />
-          {:else if $mode.mode == "neighbourhood"}
-            <NeighbourhoodMode />
-          {:else if $mode.mode == "view-shortcuts"}
-            <ViewShortcutsMode />
-          {:else if $mode.mode == "impact-one-destination"}
-            <ImpactOneDestinationMode />
-          {:else if $mode.mode == "route"}
-            <RouteMode prevMode={$mode.prevMode} />
-          {:else if $mode.mode == "predict-impact"}
-            <PredictImpactMode />
-          {:else if $mode.mode == "impact-detail"}
-            <ImpactDetailMode road={$mode.road} />
-          {:else if $mode.mode == "debug-neighbourhood"}
-            <DebugNeighbourhoodMode />
-          {:else if $mode.mode == "debug-intersections"}
-            <DebugIntersectionsMode />
-          {:else if $mode.mode == "debug-demand"}
-            <DebugDemandMode />
+      {#if $backend}
+        <button class="secondary" on:click={zoomToFit}>
+          Zoom to fit study area
+        </button>
+        <StreetView
+          map={notNull($mapStore)}
+          maptilerBasemap={$maptilerBasemap}
+        />
+      {/if}
+    </div>
+    <div slot="main" style="position: relative; width: 100%; height: 100%;">
+      {#await getStyle($maptilerBasemap) then style}
+        <MapLibre
+          {style}
+          hash
+          bind:map
+          bounds={initialBounds}
+          on:error={(e) => {
+            // @ts-expect-error ErrorEvent isn't exported
+            console.log(e.detail.error);
+          }}
+          images={[
+            {
+              id: "walk_cycle_only",
+              url: `${import.meta.env.BASE_URL}/filters/walk_cycle_only_icon.gif`,
+            },
+            {
+              id: "no_entry",
+              url: `${import.meta.env.BASE_URL}/filters/no_entry_icon.gif`,
+            },
+            {
+              id: "bus_gate",
+              url: `${import.meta.env.BASE_URL}/filters/bus_gate_icon.gif`,
+            },
+            {
+              id: "school_street",
+              url: `${import.meta.env.BASE_URL}/filters/school_street_icon.gif`,
+            },
+            {
+              id: "diagonal_filter",
+              url: `${import.meta.env.BASE_URL}/filters/diagonal_filter_icon.png`,
+            },
+            {
+              id: "no_straight_turn",
+              url: `${import.meta.env.BASE_URL}/filters/no_straight_turn.png`,
+            },
+            {
+              id: "no_left_turn",
+              url: `${import.meta.env.BASE_URL}/filters/no_left_turn.png`,
+            },
+            {
+              id: "no_right_turn",
+              url: `${import.meta.env.BASE_URL}/filters/no_right_turn.png`,
+            },
+            {
+              id: "no_u_left_to_right_turn",
+              url: `${import.meta.env.BASE_URL}/filters/no_u_left_to_right_turn.png`,
+            },
+            {
+              id: "no_u_right_to_left_turn",
+              url: `${import.meta.env.BASE_URL}/filters/no_u_right_to_left_turn.png`,
+            },
+            {
+              id: "oneway_arrow",
+              url: onewayArrowUrl,
+            },
+            {
+              id: "national_rail",
+              url: nationalRailUrl,
+            },
+          ]}
+        >
+          <NavigationControl />
+          <ScaleControl />
+          <Geocoder {map} apiKey={maptilerApiKey} country={undefined} />
+          {#if $projectName.startsWith("ltn_cnt/")}
+            <ContextualLayers />
           {/if}
-        {/if}
-        <DisableInteractiveLayers />
-      </MapLibre>
-    {/await}
-  </div>
-</Layout>
+
+          <div bind:this={mapDiv} />
+
+          {#if $mode.mode == "title"}
+            <TitleMode {wasmReady} firstLoad={$mode.firstLoad} />
+          {:else if $mode.mode == "new-project"}
+            <NewProjectMode />
+          {/if}
+          {#if $backend}
+            <GeoJSON data={$backend.getInvertedBoundary()}>
+              <FillLayer
+                {...layerId("boundary")}
+                paint={{ "fill-color": "black", "fill-opacity": 0.3 }}
+              />
+            </GeoJSON>
+            {#if $mode.mode == "pick-neighbourhood"}
+              <PickNeighbourhoodMode />
+            {:else if $mode.mode == "set-boundary"}
+              <SetBoundaryMode name={$mode.name} existing={$mode.existing} />
+            {:else if $mode.mode == "auto-boundaries"}
+              <AutoBoundariesMode />
+            {:else if $mode.mode == "neighbourhood"}
+              <NeighbourhoodMode />
+            {:else if $mode.mode == "view-shortcuts"}
+              <ViewShortcutsMode />
+            {:else if $mode.mode == "impact-one-destination"}
+              <ImpactOneDestinationMode />
+            {:else if $mode.mode == "route"}
+              <RouteMode prevMode={$mode.prevMode} />
+            {:else if $mode.mode == "predict-impact"}
+              <PredictImpactMode />
+            {:else if $mode.mode == "impact-detail"}
+              <ImpactDetailMode road={$mode.road} />
+            {:else if $mode.mode == "debug-neighbourhood"}
+              <DebugNeighbourhoodMode />
+            {:else if $mode.mode == "debug-intersections"}
+              <DebugIntersectionsMode />
+            {:else if $mode.mode == "debug-demand"}
+              <DebugDemandMode />
+            {/if}
+          {/if}
+          <DisableInteractiveLayers />
+        </MapLibre>
+      {/await}
+    </div>
+  </Layout>
+</div>
 
 <style>
   :global(.pico .icon-btn.destructive),

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -43,11 +43,11 @@
   import Settings from "./Settings.svelte";
   import {
     backend,
+    currentProjectKey,
     map as mapStore,
     maptilerApiKey,
     maptilerBasemap,
     mode,
-    projectName,
     showAbout,
     useLocalVite,
   } from "./stores";
@@ -215,7 +215,7 @@
           <NavigationControl />
           <ScaleControl />
           <Geocoder {map} apiKey={maptilerApiKey} country={undefined} />
-          {#if $projectName.startsWith("ltn_cnt/")}
+          {#if $currentProjectKey.startsWith("ltn_cnt/")}
             <ContextualLayers />
           {/if}
 

--- a/web/src/AutoBoundariesMode.svelte
+++ b/web/src/AutoBoundariesMode.svelte
@@ -31,9 +31,9 @@
   import {
     autosave,
     backend,
+    currentProjectKey,
     editPerimeterRoads,
     mode,
-    projectName,
   } from "./stores";
   import type { GeneratedBoundaryFeature } from "./wasm";
 
@@ -202,7 +202,7 @@
 
   <div slot="sidebar">
     <BackButton on:click={() => ($mode = { mode: "pick-neighbourhood" })} />
-    {#if $projectName.startsWith("ltn_cnt/")}
+    {#if $currentProjectKey.startsWith("ltn_cnt/")}
       <h3>Prioritization</h3>
       <p>Compare metrics across candidate neighbourhoods.</p>
       <PrioritizationSelect bind:selectedPrioritization />

--- a/web/src/PickNeighbourhoodMode.svelte
+++ b/web/src/PickNeighbourhoodMode.svelte
@@ -28,9 +28,9 @@
   import {
     autosave,
     backend,
+    currentProjectKey,
     editPerimeterRoads,
     mode,
-    projectName,
   } from "./stores";
   import type { NeighbourhoodBoundaryFeature } from "./wasm";
 
@@ -86,7 +86,7 @@
 
   function exportGJ() {
     downloadGeneratedFile(
-      $projectName + ".geojson",
+      $currentProjectKey + ".geojson",
       JSON.stringify($backend!.toSavefile()),
     );
   }
@@ -268,14 +268,14 @@
       </li>
     </ul>
 
-    {#if $projectName.startsWith("ltn_cnt/")}
+    {#if $currentProjectKey.startsWith("ltn_cnt/")}
       <h3>Prioritization</h3>
       <p>Compare metrics across your neighbourhoods.</p>
       <PrioritizationSelect bind:selectedPrioritization />
       <hr />
     {/if}
 
-    <p>Current project: {$projectName}</p>
+    <p>Current project: {$currentProjectKey}</p>
 
     <p>
       {edits.modalFilters} new modal filter(s) added

--- a/web/src/prioritization/PrioritizationSelect.svelte
+++ b/web/src/prioritization/PrioritizationSelect.svelte
@@ -10,7 +10,7 @@
     stats19Limits,
   } from "../common/colors";
   import SequentialLegendBucketed from "../common/SequentialLegendBucketed.svelte";
-  import { projectName } from "../stores";
+  import { currentProjectKey } from "../stores";
   import type { Prioritization } from "./index";
 
   export let selectedPrioritization: Prioritization;
@@ -29,7 +29,7 @@
     }
   }
 
-  if ($projectName.startsWith("ltn_cnt/")) {
+  if ($currentProjectKey.startsWith("ltn_cnt/")) {
     setSelectedPrioritizationFromURL();
   } else {
     selectedPrioritization = "none";

--- a/web/src/stores.ts
+++ b/web/src/stores.ts
@@ -61,7 +61,7 @@ export type Mode =
 export let map: Writable<Map | null> = writable(null);
 
 // The exact key in local storage
-export let projectName: Writable<string> = writable("");
+export let currentProjectKey: Writable<string> = writable("");
 // False until user activates
 export let showAbout: Writable<boolean> = writable(false);
 
@@ -85,7 +85,7 @@ export let roadStyle: Writable<"shortcuts" | "cells" | "edits" | "speeds"> =
 export let thickRoadsForShortcuts = writable(false);
 
 export function autosave() {
-  let key = get(projectName);
+  let key = get(currentProjectKey);
   if (!key) {
     window.alert("Autosave failed; no projectName set?!");
   }

--- a/web/src/title/NewProjectMode.svelte
+++ b/web/src/title/NewProjectMode.svelte
@@ -10,9 +10,9 @@
     assetUrl,
     autosave,
     backend,
+    currentProjectKey,
     map,
     mode,
-    projectName,
   } from "../stores";
   import { Backend } from "../wasm";
   import { afterProjectLoaded, loadFromLocalStorage } from "./loader";
@@ -37,7 +37,7 @@
         e.detail.boundary,
         undefined,
       );
-      $projectName = `ltn_${newProjectName}`;
+      $currentProjectKey = `ltn_${newProjectName}`;
       afterProjectLoaded();
       // No savefile to load. Create it immediately with just the boundary
       autosave();

--- a/web/src/title/NewProjectMode.svelte
+++ b/web/src/title/NewProjectMode.svelte
@@ -52,6 +52,8 @@
       return;
     }
 
+    // REIVEW: can we change to be like this to align with ltn_cnt project keys?
+    //let key = `ltn/${example}/${newProjectName}`;
     let key = `ltn_${newProjectName}`;
     window.localStorage.setItem(
       key,

--- a/web/src/title/TitleMode.svelte
+++ b/web/src/title/TitleMode.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { Pencil, Trash2 } from "lucide-svelte";
+  import { getContext } from "svelte";
   import { Loading } from "svelte-utils";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
+  import type { AppFocus } from "../App.svelte";
+  import CntChooseArea from "../CntChooseArea.svelte";
   import { Link } from "../common";
   import { routeTool } from "../common/draw_area/stores";
   import { backend, map, mode, projectName } from "../stores";
@@ -11,6 +14,7 @@
   export let firstLoad: boolean;
 
   let loading = "";
+  let appFocus: AppFocus = getContext("appFocus");
 
   // When other modes reset here, they can't clear state without a race condition
   {
@@ -119,50 +123,65 @@
   </div>
   <div slot="sidebar">
     {#if $map && wasmReady}
-      <div>
-        <Link on:click={() => ($mode = { mode: "new-project" })}>
-          New project
-        </Link>
-      </div>
+      {#if appFocus == "global"}
+        <div>
+          <Link on:click={() => ($mode = { mode: "new-project" })}>
+            New project
+          </Link>
+        </div>
 
-      <p>Load a saved project:</p>
-      <ul>
-        {#each projectList as [study_area_name, projects]}
-          <u>{study_area_name ?? "custom area"}</u>
-          {#each projects as project}
-            <li>
-              <span style="display: flex; justify-content: space-between;">
-                <Link on:click={() => loadProject(project)}>
-                  {project.slice("ltn_".length)}
-                </Link>
-                <span style="display: flex; gap: 16px;">
-                  <button
-                    class="outline icon-btn"
-                    aria-label="Rename project"
-                    on:click={() => renameProject(project)}
-                  >
-                    <Pencil color="black" />
-                  </button>
-                  <button
-                    class="icon-btn destructive"
-                    aria-label="Delete project"
-                    on:click={() => deleteProject(project)}
-                  >
-                    <Trash2 color="white" />
-                  </button>
+        <p>Load a saved project:</p>
+        <ul>
+          {#each projectList as [study_area_name, projects]}
+            <u>{study_area_name ?? "custom area"}</u>
+            {#each projects as project}
+              <li>
+                <span style="display: flex; justify-content: space-between;">
+                  <Link on:click={() => loadProject(project)}>
+                    {project.slice("ltn_".length)}
+                  </Link>
+                  <span style="display: flex; gap: 16px;">
+                    <button
+                      class="outline icon-btn"
+                      aria-label="Rename project"
+                      on:click={() => renameProject(project)}
+                    >
+                      <Pencil color="black" />
+                    </button>
+                    <button
+                      class="icon-btn destructive"
+                      aria-label="Delete project"
+                      on:click={() => deleteProject(project)}
+                    >
+                      <Trash2 color="white" />
+                    </button>
+                  </span>
                 </span>
-              </span>
-            </li>
+              </li>
+            {/each}
           {/each}
-        {/each}
-      </ul>
+        </ul>
 
-      <label>
-        Load a project from a file
-        <input bind:this={fileInput} on:change={loadFile} type="file" />
-      </label>
+        <label>
+          Load a project from a file
+          <input bind:this={fileInput} on:change={loadFile} type="file" />
+        </label>
+      {:else if appFocus == "cnt"}
+        <CntChooseArea {loadProject} bind:activityIndicatorText={loading} />
+      {/if}
     {:else}
       <p>Waiting for MapLibre and WASM to load...</p>
     {/if}
   </div>
 </SplitComponent>
+
+<style>
+  /* app specificity to override existing rule for .left  */
+  :global(#app .app-focus-cnt .left) {
+    width: 35%;
+  }
+  /* app specificity to override existing rule for .left  */
+  :global(#app .app-focus-cnt .main) {
+    width: 65%;
+  }
+</style>

--- a/web/src/title/TitleMode.svelte
+++ b/web/src/title/TitleMode.svelte
@@ -7,7 +7,7 @@
   import CntChooseArea from "../CntChooseArea.svelte";
   import { Link } from "../common";
   import { routeTool } from "../common/draw_area/stores";
-  import { backend, map, mode, projectName } from "../stores";
+  import { backend, currentProjectKey, map, mode } from "../stores";
   import { loadFromLocalStorage } from "./loader";
 
   export let wasmReady: boolean;
@@ -20,7 +20,7 @@
   {
     $backend = null;
     $routeTool = null;
-    $projectName = "";
+    $currentProjectKey = "";
 
     if (firstLoad) {
       let params = new URLSearchParams(window.location.search);

--- a/web/src/title/loader.ts
+++ b/web/src/title/loader.ts
@@ -9,10 +9,10 @@ import { routeTool } from "../common/draw_area/stores";
 import {
   assetUrl,
   backend,
+  currentProjectKey,
   map,
   mode,
   one_destination,
-  projectName,
   route_pt_a,
   route_pt_b,
 } from "../stores";
@@ -46,8 +46,7 @@ export async function createNewProject(
 }
 
 export async function loadFromLocalStorage(key: string) {
-  // REVIEW: rename this to "projectKey" or something - it's more than just the projectName.
-  projectName.set(key);
+  currentProjectKey.set(key);
   try {
     let gj = JSON.parse(window.localStorage.getItem(key)!);
 
@@ -72,7 +71,7 @@ export async function loadFromLocalStorage(key: string) {
     afterProjectLoaded();
   } catch (err) {
     window.alert(`Couldn't open project: ${err}`);
-    projectName.set("");
+    currentProjectKey.set("");
   }
 }
 
@@ -162,7 +161,7 @@ export function afterProjectLoaded() {
 
   // Update the URL
   let url = new URL(window.location.href);
-  url.searchParams.set("project", get(projectName));
+  url.searchParams.set("project", get(currentProjectKey));
   window.history.replaceState(null, "", url.toString());
 }
 

--- a/web/src/title/loader.ts
+++ b/web/src/title/loader.ts
@@ -18,7 +18,35 @@ import {
 } from "../stores";
 import { Backend } from "../wasm";
 
+// Returns whether the project name is already taken, otherwise the project is created.
+export async function createNewProject(
+  kind: "ltn_cnt" | "ltn",
+  studyAreaName: string,
+  projectName: string,
+): Promise<boolean> {
+  console.assert(studyAreaName != "");
+  console.assert(projectName != "");
+
+  let key = `${kind}/${studyAreaName}/${projectName}`;
+
+  if (window.localStorage.getItem(key)) {
+    return false;
+  }
+
+  window.localStorage.setItem(
+    key,
+    JSON.stringify({
+      type: "FeatureCollection",
+      features: [],
+      study_area_name: studyAreaName,
+    }),
+  );
+  await loadFromLocalStorage(key);
+  return true;
+}
+
 export async function loadFromLocalStorage(key: string) {
+  // REVIEW: rename this to "projectKey" or something - it's more than just the projectName.
   projectName.set(key);
   try {
     let gj = JSON.parse(window.localStorage.getItem(key)!);


### PR DESCRIPTION
FXIES #205 (part of #104)

This ended up not being a huge change (if you hide whitespace diff). In fact it got much smaller over time as I continued to work on it. But wow, each of these lines was hard fought.

Recall my first attempt was at https://github.com/a-b-street/ltn/issues/104#issuecomment-2658178251 which unified the `ltn` vs `ltn_cnt` landing pages, and introduced a dropdown to switch "app focus" between a "global" view and a "scotland" specific view. 

After talking it through with @dabreegster, it seems like that's not actually likely to reflect how cnt people will use the app. 

Where I landed, conceptually, is very similar from a datamodel perspective! We maintain an "appFocus" but now it's simply hardcoded by the root component based on the URL you access, e.g.: `App(element, {appFocus: "cnt"})`

I could imagine a more dynamic approach, but for now we only have two flavors, so I think it's fine to keep separate pages for `ltn/index.html` and `ltn/cnt.html`

Additionally, you are no longer "redirected" after creating/picking your ltn_cnt project. You stay rooted at `ltn/cnt.html` the entire time.

And as a bonus, the CNT landing page is now rendered in our typical "layout", which I think is nice from a consistency standpoint. 

https://github.com/user-attachments/assets/1691a762-24df-4111-937f-f732e4cad9a4

I think there is further followup we could do. In particular, from #104 

> Should all OSM areas be namespaced, so the URL logic can be less custom?
> Should all savefiles be namespaced as ltn_tool/boundary_name/filename?

Unifying some of these things will let us further de-dupe our implementations that currently have some copy/pasta, but I think they can be done in a subsequent PR.

Special request: I've tested this a bit, but probably not thoroughly enough yet. Can you give it a thorough hammering? I've learned I need to be more careful when mucking with the persistence layer, since we already have some production users.