### PR TITLE
Load saved CNT projects

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -123,7 +123,7 @@
 <div class="pico">
   <About />
 </div>
-<div class="app-focus-{appFocus}">
+<div class="app-focus-{$appFocusStore}">
   <Layout>
     <div slot="top" class="pico" style="display: flex">
       <button class="outline" on:click={() => ($showAbout = true)}>

--- a/web/src/CntChooseArea.svelte
+++ b/web/src/CntChooseArea.svelte
@@ -12,6 +12,7 @@
   import boundariesUrl from "../assets/cnt_boundaries.geojson?url";
   import { Link } from "./common";
   import { createNewProject } from "./title/loader";
+  import LoadSavedProject from "./title/LoadSavedProject.svelte";
 
   export let loadProject: (project: string) => void;
   export let activityIndicatorText: string;
@@ -115,6 +116,8 @@
     </div>
   {/each}
 </div>
+
+<LoadSavedProject bind:loading={activityIndicatorText} />
 
 <GeoJSON data={gj} generateId>
   <FillLayer

--- a/web/src/common/index.ts
+++ b/web/src/common/index.ts
@@ -94,3 +94,11 @@ export async function safeFetch(url: string): Promise<Response> {
 export function sum(list: number[]): number {
   return list.reduce((total, x) => total + x, 0);
 }
+
+export function stripPrefix(value: string, prefix: string): string {
+  return value.startsWith(prefix) ? value.slice(prefix.length) : value;
+}
+
+export function stripSuffix(value: string, suffix: string): string {
+  return value.endsWith(suffix) ? value.slice(0, -suffix.length) : value;
+}

--- a/web/src/title/LoadSavedProject.svelte
+++ b/web/src/title/LoadSavedProject.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { stripPrefix, stripSuffix } from "../common";
+  import { loadFromLocalStorage } from "./loader";
+
+  export let loading: string;
+
+  let fileInput: HTMLInputElement;
+
+  async function loadFile(e: Event) {
+    let filename = fileInput.files![0].name;
+    loading = `Loading from file ${filename}`;
+
+    let contents = await fileInput.files![0].text();
+    let gj = JSON.parse(contents);
+    // Is this a CNT project or a regular one?
+    let key = "";
+    if (gj.study_area_name && gj.study_area_name.startsWith("LAD_")) {
+      let kind = "ltn_cnt";
+      // Parse the project name from the filename, best effort. The user may
+      // have renamed the file.
+      let projectName = stripSuffix(
+        stripPrefix(filename, `${kind}_${gj.study_area_name}_`),
+        ".geojson",
+      );
+      key = `${kind}/${gj.study_area_name}/${projectName}`;
+    } else {
+      let projectName = stripSuffix(stripPrefix(filename, "ltn_"), ".geojson");
+      key = `ltn_${projectName}`;
+    }
+    // TODO Be careful with overwriting files
+    window.localStorage.setItem(key, contents);
+    await loadFromLocalStorage(key);
+    loading = "";
+  }
+</script>
+
+<label>
+  Load a project from a file
+  <input bind:this={fileInput} on:change={loadFile} type="file" />
+</label>

--- a/web/src/title/TitleMode.svelte
+++ b/web/src/title/TitleMode.svelte
@@ -3,10 +3,11 @@
   import { Loading } from "svelte-utils";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
   import CntChooseArea from "../CntChooseArea.svelte";
-  import { Link, stripPrefix, stripSuffix } from "../common";
+  import { Link } from "../common";
   import { routeTool } from "../common/draw_area/stores";
   import { appFocus, backend, currentProjectKey, map, mode } from "../stores";
   import { loadFromLocalStorage } from "./loader";
+  import LoadSavedProject from "./LoadSavedProject.svelte";
 
   export let wasmReady: boolean;
   export let firstLoad: boolean;
@@ -66,35 +67,6 @@
     out.sort((a, b) => a[0].localeCompare(b[0]));
     out.push(["custom", custom]);
     return out;
-  }
-
-  let fileInput: HTMLInputElement;
-  async function loadFile(e: Event) {
-    let filename = fileInput.files![0].name;
-    loading = `Loading from file ${filename}`;
-
-    let contents = await fileInput.files![0].text();
-    let gj = JSON.parse(contents);
-    // Is this a CNT project or a regular one?
-    let key = "";
-    if (gj.study_area_name && gj.study_area_name.startsWith("LAD_")) {
-      let kind = "ltn_cnt";
-      // Parse the project name from the filename, best effort. The user may
-      // have renamed the file.
-      let projectName = stripSuffix(
-        stripPrefix(filename, `${kind}_${gj.study_area_name}_`),
-        ".geojson",
-      );
-      key = `${kind}/${gj.study_area_name}/${projectName}`;
-    } else {
-      let projectName = stripSuffix(stripPrefix(filename, "ltn_"), ".geojson");
-      key = `ltn_${projectName}`;
-    }
-    // TODO Be careful with overwriting files
-    window.localStorage.setItem(key, contents);
-    projectList = getProjectList();
-    await loadFromLocalStorage(key);
-    loading = "";
   }
 
   function deleteProject(key: string) {
@@ -177,10 +149,7 @@
           {/each}
         </ul>
 
-        <label>
-          Load a project from a file
-          <input bind:this={fileInput} on:change={loadFile} type="file" />
-        </label>
+        <LoadSavedProject bind:loading />
       {:else if $appFocus == "cnt"}
         <CntChooseArea {loadProject} bind:activityIndicatorText={loading} />
       {/if}

--- a/web/src/title/loader.ts
+++ b/web/src/title/loader.ts
@@ -7,6 +7,7 @@ import { get, writable } from "svelte/store";
 import { safeFetch } from "../common";
 import { routeTool } from "../common/draw_area/stores";
 import {
+  appFocus,
   assetUrl,
   backend,
   currentProjectKey,
@@ -47,12 +48,16 @@ export async function createNewProject(
 
 export async function loadFromLocalStorage(key: string) {
   currentProjectKey.set(key);
+  let isCnt = key.startsWith("ltn_cnt/");
+  // TODO Should we also change the URL?
+  appFocus.set(isCnt ? "cnt" : "global");
+
   try {
     let gj = JSON.parse(window.localStorage.getItem(key)!);
 
     console.time("get input files");
     let { osmBuffer, demandBuffer, contextDataBuffer, boundary } =
-      await getInputFiles(gj, key.startsWith("ltn_cnt/"));
+      await getInputFiles(gj, isCnt);
     console.timeEnd("get input files");
     console.time("load");
     backend.set(


### PR DESCRIPTION
Fixes #195 

~~Diffbased on #211, please review that first.~~

Now both the global and CNT "choose project" pages have a tool to load a saved GJ file. From either of those pages, you can load any kind of file, and the app will switch to global or CNT mode accordingly... except for changing the URL.