### PR TITLE
Work on predict impact mode's visualization.

### DIFF
--- a/web/src/ImpactDetailMode.svelte
+++ b/web/src/ImpactDetailMode.svelte
@@ -62,6 +62,11 @@
       {Math.round((100 * props.after) / props.before)}% of the original traffic.
     </p>
 
+    <p>
+      Note: The routes are currently sampled, to speed things up. This one
+      sample route may represent many trips between the same points.
+    </p>
+
     <PrevNext list={routes} bind:idx />
   </div>
 

--- a/web/src/PredictImpactMode.svelte
+++ b/web/src/PredictImpactMode.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import type { Feature } from "geojson";
   import { FillLayer, GeoJSON, LineLayer } from "svelte-maplibre";
+  import { SequentialLegend } from "svelte-utils";
   import { Popup } from "svelte-utils/map";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
   import BackButton from "./BackButton.svelte";
-  import { layerId, Link, SequentialLegendBucketed } from "./common";
+  import { layerId, Link } from "./common";
   import { ModalFilterLayer } from "./layers";
   import { backend, mode, returnToChooseProject } from "./stores";
 
@@ -58,9 +59,9 @@
       any road: {impactGj.max_count.toLocaleString()}
     </p>
 
-    <SequentialLegendBucketed
+    <SequentialLegend
       colorScale={divergingScale}
-      buckets={["0%", "50%", "same", "150%", "200%"]}
+      limits={["0%", "50%", "same", "150%", "200%"]}
     />
   </div>
 

--- a/web/src/common/SequentialLegendBucketed.svelte
+++ b/web/src/common/SequentialLegendBucketed.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   export let colorScale: string[];
-  export let buckets: number[];
+  export let buckets: any[];
   export let decimalPlaces = 0;
 </script>
 

--- a/web/src/common/index.ts
+++ b/web/src/common/index.ts
@@ -4,11 +4,13 @@ import type {
 } from "maplibre-gl";
 
 export { default as BasemapPicker } from "./BasemapPicker.svelte";
+export { default as ContextLayerButton } from "./ContextLayerButton.svelte";
 export { default as DisableInteractiveLayers } from "./DisableInteractiveLayers.svelte";
 export { default as DotMarker } from "./DotMarker.svelte";
 export { default as HelpButton } from "./HelpButton.svelte";
 export { default as Link } from "./Link.svelte";
 export { default as PrevNext } from "./PrevNext.svelte";
+export { default as SequentialLegendBucketed } from "./SequentialLegendBucketed.svelte";
 export { default as StreetView } from "./StreetView.svelte";
 export { layerId } from "./zorder";
 

--- a/web/src/common/zorder.ts
+++ b/web/src/common/zorder.ts
@@ -105,6 +105,7 @@ const layerZorder = [
   "shortcuts",
   "shortcuts-focus",
 
+  "predict-impact-outline",
   "predict-impact",
 
   dataviz("Building"),

--- a/web/src/context/BusRoutes.svelte
+++ b/web/src/context/BusRoutes.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { LineLayer, VectorTileSource } from "svelte-maplibre";
-  import { layerId, roadLineWidth } from "../common";
-  import ContextLayerButton from "../common/ContextLayerButton.svelte";
+  import { ContextLayerButton, layerId, roadLineWidth } from "../common";
   import { assetUrl } from "../stores";
 
   let show = false;

--- a/web/src/context/CBD.svelte
+++ b/web/src/context/CBD.svelte
@@ -2,8 +2,7 @@
   import { LineLayer, VectorTileSource } from "svelte-maplibre";
   import { QualitativeLegend, SequentialLegend } from "svelte-utils";
   import { constructMatchExpression } from "svelte-utils/map";
-  import { layerId, roadLineWidth } from "../common";
-  import ContextLayerButton from "../common/ContextLayerButton.svelte";
+  import { ContextLayerButton, layerId, roadLineWidth } from "../common";
   import { assetUrl } from "../stores";
 
   // The NPT project bundles together a few layers into one pmtiles file, all

--- a/web/src/context/POIs.svelte
+++ b/web/src/context/POIs.svelte
@@ -2,8 +2,7 @@
   import { CircleLayer, GeoJSON } from "svelte-maplibre";
   import { QualitativeLegend } from "svelte-utils";
   import { constructMatchExpression, Popup } from "svelte-utils/map";
-  import { layerId } from "../common";
-  import ContextLayerButton from "../common/ContextLayerButton.svelte";
+  import { ContextLayerButton, layerId } from "../common";
   import { backend } from "../stores";
 
   let show = false;

--- a/web/src/context/Population.svelte
+++ b/web/src/context/Population.svelte
@@ -7,7 +7,11 @@
   } from "svelte-maplibre";
   import { SequentialLegend } from "svelte-utils";
   import { makeRamp, Popup } from "svelte-utils/map";
-  import { layerId } from "../common";
+  import {
+    ContextLayerButton,
+    layerId,
+    SequentialLegendBucketed,
+  } from "../common";
   import {
     bucketize,
     densityColorScale,
@@ -15,8 +19,6 @@
     simdColorScale,
     simdLimits,
   } from "../common/colors";
-  import ContextLayerButton from "../common/ContextLayerButton.svelte";
-  import SequentialLegendBucketed from "../common/SequentialLegendBucketed.svelte";
   import { assetUrl } from "../stores";
 
   let showSIMD = false;

--- a/web/src/context/RailwayStations.svelte
+++ b/web/src/context/RailwayStations.svelte
@@ -2,8 +2,7 @@
   import { GeoJSON, SymbolLayer } from "svelte-maplibre";
   import { Popup } from "svelte-utils/map";
   import nationalRailUrl from "../../assets/national_rail.png?url";
-  import { layerId } from "../common";
-  import ContextLayerButton from "../common/ContextLayerButton.svelte";
+  import { ContextLayerButton, layerId } from "../common";
   import { assetUrl } from "../stores";
 
   let show = false;

--- a/web/src/context/RouteNetwork.svelte
+++ b/web/src/context/RouteNetwork.svelte
@@ -5,8 +5,7 @@
   } from "maplibre-gl";
   import { LineLayer, VectorTileSource } from "svelte-maplibre";
   import { makeRamp, Popup } from "svelte-utils/map";
-  import { layerId } from "../common";
-  import ContextLayerButton from "../common/ContextLayerButton.svelte";
+  import { ContextLayerButton, layerId } from "../common";
   import { assetUrl } from "../stores";
 
   let show = false;

--- a/web/src/context/Stats19.svelte
+++ b/web/src/context/Stats19.svelte
@@ -7,8 +7,7 @@
   } from "svelte-maplibre";
   import { QualitativeLegend } from "svelte-utils";
   import { makeRamp, Popup } from "svelte-utils/map";
-  import { layerId } from "../common";
-  import ContextLayerButton from "../common/ContextLayerButton.svelte";
+  import { ContextLayerButton, layerId } from "../common";
   import { assetUrl } from "../stores";
 
   let show = false;

--- a/web/src/prioritization/PrioritizationSelect.svelte
+++ b/web/src/prioritization/PrioritizationSelect.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { SequentialLegend } from "svelte-utils";
+  import { SequentialLegendBucketed } from "../common";
   import {
     bucketize,
     densityColorScale,
@@ -11,7 +12,6 @@
     stats19ColorScale,
     stats19Limits,
   } from "../common/colors";
-  import SequentialLegendBucketed from "../common/SequentialLegendBucketed.svelte";
   import { appFocus } from "../stores";
   import type { Prioritization } from "./index";
 


### PR DESCRIPTION
- Workaround a bug where there are no example routes crossing somewhere
- Add a legend and outline the colors on the map
- Show neighbourhoods, for context where to expect green interior roads

Towards #36. Nothing in this mode here is really that nice yet, these're just little steps.

Before:
![image](https://github.com/user-attachments/assets/c61f2187-6f23-46f4-b19e-6d91d2658997)
After:
![image](https://github.com/user-attachments/assets/3a0157ce-6608-47b0-a1ee-ac2c05efe5df)

---

I'm also thinking about optionally hiding or de-emphasizing some icons when zoomed. I'm having trouble seeing what's "important" here that the user did to cause all the changes shown:
![image](https://github.com/user-attachments/assets/ee00c66b-4a76-42b4-a4f1-95dcfc559759)
If I hide unedited filters and TRs, the patterns of green and red in the neighbourhood make more intuitive sense:
![image](https://github.com/user-attachments/assets/d9a1bbbb-6779-456d-ac8d-1e285b7018dc)
Any opinions here?