### PR TITLE
Draggable route markers starts on screen.

### DIFF
--- a/web/src/RouteMode.svelte
+++ b/web/src/RouteMode.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import { GeoJSON, LineLayer } from "svelte-maplibre";
   import { constructMatchExpression } from "svelte-utils/map";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
@@ -20,11 +21,12 @@
   } from "./layers";
   import {
     backend,
+    ensurePointInVisibleBounds,
     mainRoadPenalty,
     mode,
     returnToChooseProject,
-    route_pt_a,
-    route_pt_b,
+    routePtA,
+    routePtB,
   } from "./stores";
 
   export let prevMode:
@@ -32,7 +34,15 @@
     | "neighbourhood"
     | "impact-one-destination";
 
-  $: gj = $backend!.compareRoute($route_pt_a, $route_pt_b, $mainRoadPenalty);
+  $: gj = $backend!.compareRoute($routePtA, $routePtB, $mainRoadPenalty);
+
+  onMount(() => {
+    // There seems to be a race with the Marker component, so we wait just a bit before updating.
+    setTimeout(() => {
+      ensurePointInVisibleBounds(routePtA);
+      ensurePointInVisibleBounds(routePtB);
+    }, 10);
+  });
 
   function back() {
     $mode = { mode: prevMode };
@@ -126,7 +136,7 @@
       />
     </GeoJSON>
 
-    <DotMarker bind:lngLat={$route_pt_a} draggable>A</DotMarker>
-    <DotMarker bind:lngLat={$route_pt_b} draggable>B</DotMarker>
+    <DotMarker bind:lngLat={$routePtA} draggable>A</DotMarker>
+    <DotMarker bind:lngLat={$routePtB} draggable>B</DotMarker>
   </div>
 </SplitComponent>

--- a/web/src/stores.ts
+++ b/web/src/stores.ts
@@ -1,5 +1,10 @@
 import type { Feature, Polygon } from "geojson";
-import { LngLat, type LngLatBoundsLike, type Map } from "maplibre-gl";
+import {
+  LngLat,
+  LngLatBounds,
+  type LngLatBoundsLike,
+  type Map,
+} from "maplibre-gl";
 import { type AreaProps } from "route-snapper-ts";
 import { get, writable, type Writable } from "svelte/store";
 import type { Backend } from "./wasm";
@@ -68,9 +73,9 @@ export let showAbout: Writable<boolean> = writable(false);
 export let appFocus: Writable<"global" | "cnt"> = writable("global");
 
 export let backend: Writable<Backend | null> = writable(null);
-export let route_pt_a: Writable<LngLat> = writable(new LngLat(0, 0));
-export let route_pt_b: Writable<LngLat> = writable(new LngLat(0, 0));
-export let one_destination: Writable<LngLat> = writable(new LngLat(0, 0));
+export let routePtA: Writable<LngLat> = writable(new LngLat(0, 0));
+export let routePtB: Writable<LngLat> = writable(new LngLat(0, 0));
+export let oneDestination: Writable<LngLat> = writable(new LngLat(0, 0));
 export let mainRoadPenalty: Writable<number> = writable(1.0);
 // A way for different components to know when internal app state has changed
 // and they might need to rerender
@@ -109,4 +114,26 @@ export function returnToChooseProject() {
     bounds = [-8.943, 54.631, -0.901, 59.489];
   }
   get(map)?.fitBounds(bounds, { duration: 500 });
+}
+
+export function ensurePointInVisibleBounds(point: Writable<LngLat>) {
+  function randomPoint(bounds: LngLatBounds): LngLat {
+    const width = bounds.getEast() - bounds.getWest();
+    let lng = bounds.getWest() + Math.random() * width;
+
+    const height = bounds.getNorth() - bounds.getSouth();
+    let lat = bounds.getSouth() + Math.random() * height;
+
+    return new LngLat(lng, lat);
+  }
+
+  const bounds: LngLatBounds | undefined = get(map)?.getBounds();
+  if (!bounds) {
+    console.assert(false, "missing map bounds");
+    return;
+  }
+
+  if (!bounds.contains(get(point))) {
+    point.set(randomPoint(bounds));
+  }
 }

--- a/web/src/title/loader.ts
+++ b/web/src/title/loader.ts
@@ -1,5 +1,4 @@
 import type { Feature, Polygon } from "geojson";
-import { LngLat } from "maplibre-gl";
 import { RouteTool } from "route-snapper-ts";
 import { emptyGeojson } from "svelte-utils/map";
 import { overpassQueryForPolygon } from "svelte-utils/overpass";
@@ -13,9 +12,6 @@ import {
   currentProjectKey,
   map,
   mode,
-  one_destination,
-  route_pt_a,
-  route_pt_b,
 } from "../stores";
 import { Backend } from "../wasm";
 
@@ -160,19 +156,9 @@ export function afterProjectLoaded() {
     ),
   );
   get(map)!.fitBounds(get(backend)!.getBounds(), { duration: 500 });
-  route_pt_a.set(randomPoint());
-  route_pt_b.set(randomPoint());
-  one_destination.set(randomPoint());
 
   // Update the URL
   let url = new URL(window.location.href);
   url.searchParams.set("project", get(currentProjectKey));
   window.history.replaceState(null, "", url.toString());
-}
-
-function randomPoint(): LngLat {
-  let bounds = get(backend)!.getBounds();
-  let lng = bounds[0] + Math.random() * (bounds[2] - bounds[0]);
-  let lat = bounds[1] + Math.random() * (bounds[3] - bounds[1]);
-  return new LngLat(lng, lat);
 }


### PR DESCRIPTION
FIXES #72 

They are persisted, which is convenient when you want to see how your changes are affecting the route, but it's confusing, especially for new users, to see this route off screen.


Another thought I had, literally after I'd done all the work and was typing up the commit message:
Maybe another approach would be to leave the logic as is, and zoom out the bounds to encompass the markers.