### PR TITLE
cartographic delights

### DIFF
--- a/web/assets/map-styles/streets-v2-style.json
+++ b/web/assets/map-styles/streets-v2-style.json
@@ -1,0 +1,8165 @@
+{
+  "version": 8,
+  "id": "streets-v2",
+  "name": "Streets",
+  "sources": {
+    "maptiler_attribution": {
+      "attribution": "<a href=\"https://www.maptiler.com/copyright/\" target=\"_blank\">&copy; MapTiler</a> <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">&copy; OpenStreetMap contributors</a>",
+      "type": "vector"
+    },
+    "maptiler_planet": {
+      "url": "https://api.maptiler.com/tiles/v3/tiles.json?key=MZEJTanw3WpxRvt7qDfo",
+      "type": "vector"
+    }
+  },
+  "layers": [
+    {
+      "id": "Background",
+      "type": "background",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "background-color": {
+          "stops": [
+            [
+              6,
+              "hsl(47,79%,94%)"
+            ],
+            [
+              14,
+              "hsl(42,49%,93%)"
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "Meadow",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "globallandcover",
+      "maxzoom": 8,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(75,51%,85%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              0,
+              1
+            ],
+            [
+              8,
+              0.1
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "class",
+        "grass"
+      ]
+    },
+    {
+      "id": "Scrub",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "globallandcover",
+      "maxzoom": 8,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(97,51%,80%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              0,
+              1
+            ],
+            [
+              8,
+              0.1
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "class",
+        "scrub"
+      ]
+    },
+    {
+      "id": "Crop",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "globallandcover",
+      "maxzoom": 8,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(50,67%,86%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              0,
+              1
+            ],
+            [
+              8,
+              0.1
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "class",
+        "crop"
+      ]
+    },
+    {
+      "id": "Glacier",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landcover",
+      "maxzoom": 24,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(0,0%,100%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              0,
+              1
+            ],
+            [
+              10,
+              0.7
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "class",
+        "ice"
+      ]
+    },
+    {
+      "id": "Forest",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "globallandcover",
+      "maxzoom": 8,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(119,38%,76%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              1,
+              0.8
+            ],
+            [
+              8,
+              0
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "in",
+        "class",
+        "forest",
+        "tree"
+      ]
+    },
+    {
+      "id": "Sand",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landcover",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": false,
+        "fill-color": "hsl(52,93%,89%)",
+        "fill-opacity": 0.85
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "class",
+        "sand"
+      ]
+    },
+    {
+      "id": "Wood",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landcover",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsl(87,46%,85%)",
+        "fill-opacity": 1
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "class",
+        "wood"
+      ]
+    },
+    {
+      "id": "Residential",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landuse",
+      "maxzoom": 24,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": {
+          "base": 1,
+          "stops": [
+            [
+              4,
+              "hsl(44,34%,87%)"
+            ],
+            [
+              16,
+              "hsl(54, 45%, 91%)"
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "class",
+        "residential",
+        "suburbs",
+        "neighbourhood"
+      ]
+    },
+    {
+      "id": "Industrial",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landuse",
+      "maxzoom": 24,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          9,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "industrial"
+            ],
+            "hsl(40,67%,90%)",
+            "quarry",
+            "hsla(32, 47%, 87%, 0.2)",
+            "hsl(60, 31%, 87%)"
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "industrial"
+            ],
+            "hsl(49,54%,90%)",
+            "quarry",
+            "hsla(32, 47%, 87%, 0.5)",
+            "hsl(60, 31%, 87%)"
+          ]
+        ],
+        "fill-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          1,
+          9,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            "quarry",
+            0,
+            1
+          ],
+          10,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "class",
+        "industrial",
+        "quarry"
+      ]
+    },
+    {
+      "id": "Grass",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landcover",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": false,
+        "fill-color": "hsl(103, 40%, 85%)",
+        "fill-opacity": 0.5
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "class",
+        "grass"
+      ]
+    },
+    {
+      "id": "Airport zone",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsl(0,0%,93%)",
+        "fill-opacity": 1
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "$type",
+        "Polygon"
+      ]
+    },
+    {
+      "id": "Pedestrian",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsl(43,100%,99%)",
+        "fill-opacity": 0.7
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ],
+        [
+          "!in",
+          "class",
+          "bridge",
+          "pier"
+        ],
+        [
+          "in",
+          "subclass",
+          "pedestrian",
+          "platform"
+        ]
+      ]
+    },
+    {
+      "id": "Cemetery",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landuse",
+      "minzoom": 9,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(0,0%,88%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              9,
+              0.25
+            ],
+            [
+              16,
+              1
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "class",
+        "cemetery"
+      ]
+    },
+    {
+      "id": "Hospital",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landuse",
+      "minzoom": 9,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(12,63%,94%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              9,
+              0.25
+            ],
+            [
+              16,
+              1
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "class",
+        "hospital"
+      ]
+    },
+    {
+      "id": "Stadium",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landuse",
+      "minzoom": 9,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(94, 100%, 88%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              9,
+              0.25
+            ],
+            [
+              16,
+              1
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "class",
+        "pitch",
+        "stadium",
+        "playground"
+      ]
+    },
+    {
+      "id": "School",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "landuse",
+      "minzoom": 9,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(194,52%,94%)",
+        "fill-opacity": {
+          "stops": [
+            [
+              9,
+              0.25
+            ],
+            [
+              16,
+              1
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "class",
+        "college",
+        "school",
+        "university"
+      ]
+    },
+    {
+      "id": "River tunnel",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "waterway",
+      "minzoom": 14,
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(210,73%,78%)",
+        "line-dasharray": [
+          2,
+          4
+        ],
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "brunnel",
+        "tunnel"
+      ]
+    },
+    {
+      "id": "River",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "waterway",
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(210,73%,78%)",
+        "line-width": {
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "!=",
+        "brunnel",
+        "tunnel"
+      ]
+    },
+    {
+      "id": "Water intermittent",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "water",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(205,91%,83%)",
+        "fill-opacity": 0.85
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "intermittent",
+        1
+      ]
+    },
+    {
+      "id": "Water",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "water",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(204,92%,75%)",
+        "fill-opacity": [
+          "match",
+          [
+            "get",
+            "intermittent"
+          ],
+          1,
+          0.85,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "!=",
+        "intermittent",
+        1
+      ]
+    },
+    {
+      "id": "Aeroway",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,100%)",
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          11,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "runway"
+            ],
+            3,
+            0.5
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "runway"
+            ],
+            16,
+            6
+          ]
+        ]
+      },
+      "metadata": {}
+    },
+    {
+      "id": "Heliport",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "aeroway",
+      "minzoom": 11,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsl(0,0%,100%)",
+        "fill-opacity": 1
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "class",
+        "helipad",
+        "heliport"
+      ]
+    },
+    {
+      "id": "Ferry line",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 6,
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              10,
+              "hsl(205,61%,63%)"
+            ],
+            [
+              16,
+              "hsl(205,67%,47%)"
+            ]
+          ]
+        },
+        "line-dasharray": [
+          2,
+          2
+        ],
+        "line-opacity": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          0.5,
+          7,
+          0.8,
+          8,
+          1
+        ],
+        "line-width": {
+          "stops": [
+            [
+              10,
+              0.5
+            ],
+            [
+              14,
+              1.1
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "class",
+        "ferry"
+      ]
+    },
+    {
+      "id": "Tunnel outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "motorway",
+          "hsl(28,72%,69%)",
+          [
+            "trunk",
+            "primary"
+          ],
+          "hsl(28,72%,69%)",
+          "hsl(36,5%,80%)"
+        ],
+        "line-dasharray": [
+          0.5,
+          0.25
+        ],
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          0,
+          7,
+          0.5,
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              0,
+              2.5
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            2,
+            0
+          ],
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              2,
+              6
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            3,
+            [
+              "secondary",
+              "tertiary"
+            ],
+            2,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            1,
+            0.5
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              5,
+              8
+            ],
+            [
+              "trunk"
+            ],
+            4,
+            [
+              "primary"
+            ],
+            6,
+            [
+              "secondary"
+            ],
+            6,
+            [
+              "tertiary"
+            ],
+            4,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            3,
+            3
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway",
+              "trunk",
+              "primary"
+            ],
+            10,
+            [
+              "secondary"
+            ],
+            8,
+            [
+              "tertiary"
+            ],
+            8,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            4,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway",
+              "trunk",
+              "primary"
+            ],
+            26,
+            [
+              "secondary"
+            ],
+            26,
+            [
+              "tertiary"
+            ],
+            26,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            18,
+            18
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "!in",
+          "class",
+          "bridge",
+          "ferry",
+          "rail",
+          "transit",
+          "pier",
+          "path",
+          "aerialway",
+          "motorway_construction",
+          "trunk_construction",
+          "primary_construction",
+          "secondary_construction",
+          "tertiary_construction",
+          "minor_construction",
+          "service_construction",
+          "track_construction"
+        ]
+      ]
+    },
+    {
+      "id": "Tunnel",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "motorway",
+          "hsl(35,100%,76%)",
+          [
+            "trunk",
+            "primary"
+          ],
+          "hsl(48,100%,88%)",
+          "hsl(0,0%,96%)"
+        ],
+        "line-opacity": 1,
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          5,
+          0,
+          6,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "brunnel"
+              ],
+              [
+                "bridge"
+              ],
+              0,
+              1
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            0,
+            0
+          ],
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              0,
+              2.5
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            1.5,
+            1
+          ],
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              1,
+              4
+            ],
+            [
+              "trunk"
+            ],
+            2.5,
+            [
+              "primary"
+            ],
+            2.5,
+            [
+              "secondary",
+              "tertiary"
+            ],
+            1.5,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            1,
+            1
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              5,
+              6
+            ],
+            [
+              "trunk"
+            ],
+            3,
+            [
+              "primary"
+            ],
+            5,
+            [
+              "secondary"
+            ],
+            4,
+            [
+              "tertiary"
+            ],
+            3,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            2,
+            2
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway",
+              "trunk",
+              "primary"
+            ],
+            8,
+            [
+              "secondary"
+            ],
+            7,
+            [
+              "tertiary"
+            ],
+            6,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            4,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway",
+              "trunk",
+              "primary"
+            ],
+            24,
+            [
+              "secondary"
+            ],
+            24,
+            [
+              "tertiary"
+            ],
+            24,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            16,
+            16
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "!in",
+          "class",
+          "ferry",
+          "rail",
+          "transit",
+          "pier",
+          "bridge",
+          "path",
+          "aerialway",
+          "motorway_construction",
+          "trunk_construction",
+          "primary_construction",
+          "secondary_construction",
+          "tertiary_construction",
+          "minor_construction",
+          "service_construction",
+          "track_construction"
+        ]
+      ]
+    },
+    {
+      "id": "Railway tunnel",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,73%)",
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ]
+    },
+    {
+      "id": "Railway tunnel hatching",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,73%)",
+        "line-dasharray": [
+          0.2,
+          8
+        ],
+        "line-opacity": 0.5,
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              20,
+              8
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ]
+    },
+    {
+      "id": "Footway tunnel outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "miter",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,100%)",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              0
+            ],
+            [
+              16,
+              0
+            ],
+            [
+              18,
+              4
+            ],
+            [
+              22,
+              8
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "path",
+          "pedestrian"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ]
+    },
+    {
+      "id": "Footway tunnel",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,63%)",
+        "line-dasharray": {
+          "stops": [
+            [
+              14,
+              [
+                1,
+                0.5
+              ]
+            ],
+            [
+              18,
+              [
+                1,
+                0.25
+              ]
+            ]
+          ]
+        },
+        "line-opacity": 0.4,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              18,
+              2
+            ],
+            [
+              22,
+              5
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "path",
+          "pedestrian"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ]
+    },
+    {
+      "id": "Pier",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(42,49%,93%)"
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "==",
+          "class",
+          "pier"
+        ]
+      ]
+    },
+    {
+      "id": "Pier road",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(42,49%,93%)",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1
+            ],
+            [
+              17,
+              4
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "class",
+          "pier"
+        ]
+      ]
+    },
+    {
+      "id": "Bridge",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "hsl(42,49%,93%)",
+        "fill-opacity": 0.6
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ]
+    },
+    {
+      "id": "Minor road outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(36,5%,80%)",
+        "line-opacity": 1,
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          0,
+          7,
+          0.5,
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary",
+              "tertiary"
+            ],
+            2,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            1,
+            0.5
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary"
+            ],
+            6,
+            [
+              "tertiary"
+            ],
+            4,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            3,
+            3
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary"
+            ],
+            8,
+            [
+              "tertiary"
+            ],
+            8,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            4,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary"
+            ],
+            26,
+            [
+              "tertiary"
+            ],
+            26,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            18,
+            18
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "!in",
+          "class",
+          "aerialway",
+          "bridge",
+          "ferry",
+          "minor_construction",
+          "motorway",
+          "motorway_construction",
+          "path",
+          "path_construction",
+          "pier",
+          "primary",
+          "primary_construction",
+          "rail",
+          "secondary_construction",
+          "service_construction",
+          "tertiary_construction",
+          "track_construction",
+          "transit",
+          "trunk_construction"
+        ]
+      ]
+    },
+    {
+      "id": "Major road outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(28,72%,69%)",
+        "line-opacity": 1,
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          0,
+          7,
+          0.5,
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            2.4,
+            0
+          ],
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            3,
+            0.5
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk"
+            ],
+            4,
+            [
+              "primary"
+            ],
+            6,
+            3
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            10,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            26,
+            18
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ]
+      ]
+    },
+    {
+      "id": "Highway outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(28,72%,69%)",
+        "line-opacity": 1,
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          0,
+          7,
+          0.5,
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              0,
+              2.5
+            ],
+            0
+          ],
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              2,
+              6
+            ],
+            0.5
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              5,
+              8
+            ],
+            3
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            10,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            26,
+            18
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ]
+      ]
+    },
+    {
+      "id": "Road under construction",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "square",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "motorway_construction",
+          "hsl(35,100%,76%)",
+          [
+            "trunk_construction",
+            "primary_construction"
+          ],
+          "hsl(48,100%,83%)",
+          "hsl(0,0%,100%)"
+        ],
+        "line-dasharray": [
+          2,
+          2
+        ],
+        "line-opacity": [
+          "case",
+          [
+            "==",
+            [
+              "get",
+              "brunnel"
+            ],
+            "tunnel"
+          ],
+          0.7,
+          1
+        ],
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          5,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway_construction"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "brunnel"
+              ],
+              [
+                "bridge"
+              ],
+              0,
+              0.5
+            ],
+            [
+              "trunk_construction",
+              "primary_construction"
+            ],
+            0,
+            0
+          ],
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway_construction"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              0,
+              2.5
+            ],
+            [
+              "trunk_construction",
+              "primary_construction"
+            ],
+            1.5,
+            1
+          ],
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway_construction"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              1,
+              4
+            ],
+            [
+              "trunk_construction"
+            ],
+            2.5,
+            [
+              "primary_construction"
+            ],
+            2.5,
+            [
+              "secondary_construction",
+              "tertiary_construction"
+            ],
+            1.5,
+            [
+              "minor_construction",
+              "service_construction",
+              "track_construction"
+            ],
+            1,
+            1
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway_construction"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              5,
+              6
+            ],
+            [
+              "trunk_construction"
+            ],
+            3,
+            [
+              "primary_construction"
+            ],
+            5,
+            [
+              "secondary_construction"
+            ],
+            4,
+            [
+              "tertiary_construction"
+            ],
+            3,
+            [
+              "minor_construction",
+              "service_construction",
+              "track_construction"
+            ],
+            2,
+            2
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway_construction",
+              "trunk_construction",
+              "primary_construction"
+            ],
+            8,
+            [
+              "secondary_construction"
+            ],
+            7,
+            [
+              "tertiary_construction"
+            ],
+            6,
+            [
+              "minor_construction",
+              "service_construction",
+              "track_construction"
+            ],
+            4,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway_construction",
+              "trunk_construction",
+              "primary_construction"
+            ],
+            24,
+            [
+              "secondary_construction"
+            ],
+            24,
+            [
+              "tertiary_construction"
+            ],
+            24,
+            [
+              "minor_construction",
+              "service_construction",
+              "track_construction"
+            ],
+            16,
+            16
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "class",
+        "motorway_construction",
+        "trunk_construction",
+        "primary_construction",
+        "secondary_construction",
+        "tertiary_construction",
+        "minor_construction",
+        "service_construction",
+        "track_construction"
+      ]
+    },
+    {
+      "id": "Minor road",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,100%)",
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          5,
+          0.5,
+          10,
+          1,
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary",
+              "tertiary"
+            ],
+            1.5,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            1,
+            1
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary"
+            ],
+            4,
+            [
+              "tertiary"
+            ],
+            3,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            2,
+            2
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary"
+            ],
+            7,
+            [
+              "tertiary"
+            ],
+            6,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            4,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "secondary"
+            ],
+            24,
+            [
+              "tertiary"
+            ],
+            24,
+            [
+              "minor",
+              "service",
+              "track"
+            ],
+            16,
+            16
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "!in",
+          "class",
+          "aerialway",
+          "bridge",
+          "ferry",
+          "minor_construction",
+          "motorway",
+          "motorway_construction",
+          "path",
+          "path_construction",
+          "pier",
+          "primary",
+          "primary_construction",
+          "rail",
+          "secondary_construction",
+          "service_construction",
+          "tertiary_construction",
+          "track_construction",
+          "transit",
+          "trunk_construction"
+        ]
+      ]
+    },
+    {
+      "id": "Major road",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(48,100%,83%)",
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            1.5,
+            1
+          ],
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            2.5,
+            1
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk"
+            ],
+            3,
+            [
+              "primary"
+            ],
+            5,
+            2
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            8,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "trunk",
+              "primary"
+            ],
+            24,
+            16
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ]
+      ]
+    },
+    {
+      "id": "Highway",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 4,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(35,100%,76%)",
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            2
+          ],
+          [
+            "zoom"
+          ],
+          5,
+          0.5,
+          6,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "brunnel"
+              ],
+              [
+                "bridge"
+              ],
+              0,
+              1
+            ],
+            0
+          ],
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              0,
+              2.5
+            ],
+            1
+          ],
+          12,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              1,
+              4
+            ],
+            1
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            [
+              "match",
+              [
+                "get",
+                "ramp"
+              ],
+              1,
+              5,
+              6
+            ],
+            2
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            8,
+            4
+          ],
+          20,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "motorway"
+            ],
+            24,
+            16
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ]
+      ]
+    },
+    {
+      "id": "Path outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "miter",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,100%)",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              0
+            ],
+            [
+              16,
+              0
+            ],
+            [
+              18,
+              4
+            ],
+            [
+              22,
+              8
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "path",
+          "pedestrian"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ]
+    },
+    {
+      "id": "Path minor",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 79%)",
+        "line-dasharray": {
+          "stops": [
+            [
+              14,
+              [
+                1,
+                0.5
+              ]
+            ],
+            [
+              18,
+              [
+                1,
+                0.25
+              ]
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              18,
+              2
+            ],
+            [
+              22,
+              5
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "path_pedestrian"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ]
+    },
+    {
+      "id": "Path",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 12,
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 79%)",
+        "line-dasharray": {
+          "stops": [
+            [
+              14,
+              [
+                1,
+                0.5
+              ]
+            ],
+            [
+              18,
+              [
+                1,
+                0.25
+              ]
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              14,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              18,
+              2
+            ],
+            [
+              22,
+              5
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "path",
+          "pedestrian"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ]
+    },
+    {
+      "id": "Major rail",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": {
+          "stops": [
+            [
+              8,
+              "hsl(0,0%,72%)"
+            ],
+            [
+              16,
+              "hsl(0,0%,70%)"
+            ]
+          ]
+        },
+        "line-opacity": [
+          "match",
+          [
+            "get",
+            "service"
+          ],
+          "yard",
+          0.5,
+          1
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ]
+    },
+    {
+      "id": "Major rail hatching",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,72%)",
+        "line-dasharray": [
+          0.2,
+          9
+        ],
+        "line-opacity": [
+          "match",
+          [
+            "get",
+            "service"
+          ],
+          "yard",
+          0.5,
+          1
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              20,
+              8
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ]
+    },
+    {
+      "id": "Minor rail",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,73%)",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "subclass",
+        "light_rail",
+        "tram"
+      ]
+    },
+    {
+      "id": "Minor rail hatching",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,73%)",
+        "line-dasharray": [
+          0.2,
+          4
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              2
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "subclass",
+        "tram",
+        "light_rail"
+      ]
+    },
+    {
+      "id": "Building",
+      "type": "fill",
+      "source": "maptiler_planet",
+      "source-layer": "building",
+      "minzoom": 13,
+      "maxzoom": 15,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": "hsl(30,6%,73%)",
+        "fill-opacity": 0.3,
+        "fill-outline-color": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              "hsla(35, 6%, 79%, 0.3)"
+            ],
+            [
+              14,
+              "hsl(35, 6%, 79%)"
+            ]
+          ]
+        }
+      },
+      "metadata": {}
+    },
+    {
+      "id": "Building 3D",
+      "type": "fill-extrusion",
+      "source": "maptiler_planet",
+      "source-layer": "building",
+      "minzoom": 15,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-extrusion-base": {
+          "property": "render_min_height",
+          "type": "identity"
+        },
+        "fill-extrusion-color": "hsl(44,14%,79%)",
+        "fill-extrusion-height": {
+          "property": "render_height",
+          "type": "identity"
+        },
+        "fill-extrusion-opacity": 0.4
+      },
+      "metadata": {},
+      "filter": [
+        "!has",
+        "hide_3d"
+      ]
+    },
+    {
+      "id": "Aqueduct outline",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "waterway",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,51%)",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              14,
+              1
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "brunnel",
+        "bridge"
+      ]
+    },
+    {
+      "id": "Aqueduct",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "waterway",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(204,92%,75%)",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              20,
+              5
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ]
+    },
+    {
+      "id": "Cablecar",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-blur": 1,
+        "line-color": "hsl(0,0%,100%)",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              2
+            ],
+            [
+              19,
+              4
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "class",
+        "aerialway"
+      ]
+    },
+    {
+      "id": "Cablecar dash",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 13,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "bevel",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0,0%,64%)",
+        "line-dasharray": [
+          2,
+          2
+        ],
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              1
+            ],
+            [
+              19,
+              2
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "class",
+        "aerialway"
+      ]
+    },
+    {
+      "id": "Other border",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "boundary",
+      "minzoom": 3,
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 70%)",
+        "line-dasharray": [
+          2,
+          1
+        ],
+        "line-width": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          3,
+          0.75,
+          4,
+          0.8,
+          11,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "admin_level"
+              ],
+              6
+            ],
+            1.75,
+            1.5
+          ],
+          18,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "admin_level"
+              ],
+              6
+            ],
+            3,
+            2
+          ]
+        ]
+      },
+      "filter": [
+        "all",
+        [
+          "in",
+          "admin_level",
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        [
+          "==",
+          "maritime",
+          0
+        ]
+      ]
+    },
+    {
+      "id": "Disputed border",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "boundary",
+      "minzoom": 0,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 63%)",
+        "line-dasharray": [
+          2,
+          2
+        ],
+        "line-width": {
+          "stops": [
+            [
+              1,
+              0.5
+            ],
+            [
+              5,
+              1.5
+            ],
+            [
+              10,
+              2
+            ],
+            [
+              24,
+              12
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "admin_level",
+          2
+        ],
+        [
+          "==",
+          "disputed",
+          1
+        ],
+        [
+          "==",
+          "maritime",
+          0
+        ]
+      ]
+    },
+    {
+      "id": "Country border",
+      "type": "line",
+      "source": "maptiler_planet",
+      "source-layer": "boundary",
+      "minzoom": 0,
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "hsl(0, 0%, 54%)",
+        "line-width": {
+          "stops": [
+            [
+              1,
+              0.5
+            ],
+            [
+              5,
+              1.5
+            ],
+            [
+              10,
+              2
+            ],
+            [
+              24,
+              12
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "all",
+        [
+          "==",
+          "admin_level",
+          2
+        ],
+        [
+          "==",
+          "disputed",
+          0
+        ],
+        [
+          "==",
+          "maritime",
+          0
+        ]
+      ]
+    },
+    {
+      "id": "River labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "waterway",
+      "minzoom": 13,
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 400,
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Roboto Italic",
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
+        "text-size": {
+          "stops": [
+            [
+              12,
+              8
+            ],
+            [
+              16,
+              14
+            ],
+            [
+              22,
+              20
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(205,84%,39%)",
+        "text-halo-blur": 1,
+        "text-halo-color": "hsl(202, 76%, 82%)",
+        "text-halo-width": {
+          "stops": [
+            [
+              10,
+              1
+            ],
+            [
+              18,
+              2
+            ]
+          ]
+        }
+      },
+      "filter": [
+        "==",
+        "$type",
+        "LineString"
+      ]
+    },
+    {
+      "id": "Ocean labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "water_name",
+      "minzoom": 0,
+      "layout": {
+        "symbol-placement": "point",
+        "text-field": "{name:en}",
+        "text-font": [
+          "Roboto Italic",
+          "Noto Sans Italic"
+        ],
+        "text-max-width": 5,
+        "text-size": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          1,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "ocean"
+            ],
+            14,
+            10
+          ],
+          3,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "ocean"
+            ],
+            18,
+            14
+          ],
+          9,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "ocean"
+            ],
+            22,
+            18
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "lake"
+            ],
+            14,
+            [
+              "sea"
+            ],
+            20,
+            26
+          ]
+        ],
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": {
+          "stops": [
+            [
+              1,
+              "hsl(203,54%,54%)"
+            ],
+            [
+              4,
+              "hsl(203,72%,39%)"
+            ]
+          ]
+        },
+        "text-halo-blur": 1,
+        "text-halo-color": {
+          "stops": [
+            [
+              1,
+              "hsla(196, 72%, 80%, 0.05)"
+            ],
+            [
+              3,
+              "hsla(200, 100%, 88%, 0.75)"
+            ]
+          ]
+        },
+        "text-halo-width": 1,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          1,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "ocean"
+            ],
+            1,
+            0
+          ],
+          3,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "has",
+          "name"
+        ],
+        [
+          "!=",
+          "class",
+          "lake"
+        ]
+      ]
+    },
+    {
+      "id": "Lake labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "water_name",
+      "minzoom": 0,
+      "layout": {
+        "symbol-placement": "line",
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Roboto Italic",
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 5,
+        "text-size": {
+          "stops": [
+            [
+              10,
+              13
+            ],
+            [
+              14,
+              16
+            ],
+            [
+              22,
+              20
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(205,84%,39%)",
+        "text-halo-color": "hsla(0, 100%, 100%, 0.45)",
+        "text-halo-width": 1.5
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "class",
+          "lake"
+        ]
+      ]
+    },
+    {
+      "id": "Housenumber",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "housenumber",
+      "minzoom": 18,
+      "layout": {
+        "text-field": "{housenumber}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-size": 10,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(26,10%,44%)",
+        "text-halo-blur": 1,
+        "text-halo-color": "hsl(21,64%,96%)",
+        "text-halo-width": 1
+      }
+    },
+    {
+      "id": "Gondola",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 13,
+      "layout": {
+        "symbol-placement": "line",
+        "text-anchor": "center",
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Roboto Italic",
+          "Noto Sans Italic"
+        ],
+        "text-offset": [
+          0.8,
+          0.8
+        ],
+        "text-size": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              11
+            ],
+            [
+              15,
+              12
+            ],
+            [
+              18,
+              13
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(0,0%,40%)",
+        "text-halo-blur": 1,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1
+      },
+      "metadata": {},
+      "filter": [
+        "in",
+        "subclass",
+        "gondola",
+        "cable_car"
+      ]
+    },
+    {
+      "id": "Ferry",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 12,
+      "layout": {
+        "symbol-placement": "line",
+        "text-anchor": "center",
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Roboto Italic",
+          "Noto Sans Italic"
+        ],
+        "text-offset": [
+          0.8,
+          0.8
+        ],
+        "text-size": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              11
+            ],
+            [
+              15,
+              12
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(205,84%,39%)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "hsla(0, 0%, 100%, 0.15)",
+        "text-halo-width": 1
+      },
+      "filter": [
+        "==",
+        "class",
+        "ferry"
+      ]
+    },
+    {
+      "id": "Oneway",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation",
+      "minzoom": 16,
+      "layout": {
+        "icon-image": "oneway",
+        "icon-padding": 2,
+        "icon-rotate": [
+          "match",
+          [
+            "get",
+            "oneway"
+          ],
+          1,
+          0,
+          0
+        ],
+        "icon-rotation-alignment": "map",
+        "icon-size": {
+          "stops": [
+            [
+              16,
+              0.7
+            ],
+            [
+              19,
+              1
+            ]
+          ]
+        },
+        "symbol-placement": "line",
+        "symbol-spacing": 75,
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(0, 0%, 65%)",
+        "icon-opacity": 0.5
+      },
+      "filter": [
+        "all",
+        [
+          "has",
+          "oneway"
+        ],
+        [
+          "in",
+          "class",
+          "motorway",
+          "trunk",
+          "primary",
+          "secondary",
+          "tertiary",
+          "minor",
+          "service"
+        ]
+      ]
+    },
+    {
+      "id": "Road labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 8,
+      "layout": {
+        "icon-allow-overlap": false,
+        "icon-ignore-placement": false,
+        "icon-keep-upright": false,
+        "symbol-placement": "line",
+        "symbol-spacing": [
+          "step",
+          [
+            "zoom"
+          ],
+          250,
+          22,
+          500
+        ],
+        "text-allow-overlap": false,
+        "text-anchor": "center",
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-ignore-placement": false,
+        "text-justify": "center",
+        "text-max-width": 10,
+        "text-offset": [
+          0,
+          0.15
+        ],
+        "text-optional": false,
+        "text-size": {
+          "stops": [
+            [
+              13,
+              10
+            ],
+            [
+              14,
+              11
+            ],
+            [
+              18,
+              13
+            ],
+            [
+              22,
+              15
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(0, 0%, 16%)",
+        "text-color": "hsl(0, 0%, 16%)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "!in",
+          "subclass",
+          "gondola",
+          "cable_car"
+        ],
+        [
+          "!in",
+          "class",
+          "ferry",
+          "service"
+        ]
+      ]
+    },
+    {
+      "id": "Highway junction",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 16,
+      "layout": {
+        "icon-image": "exit_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "point",
+        "symbol-spacing": 200,
+        "symbol-z-order": "auto",
+        "text-field": "{ref}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-offset": [
+          0,
+          0.1
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 9,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(0,0%,21%)",
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1
+      },
+      "filter": [
+        "all",
+        [
+          ">",
+          "ref_length",
+          0
+        ],
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "==",
+          "subclass",
+          "junction"
+        ]
+      ]
+    },
+    {
+      "id": "Highway shield",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 8,
+      "layout": {
+        "icon-image": "road_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-avoid-edges": true,
+        "symbol-placement": "line",
+        "symbol-spacing": {
+          "stops": [
+            [
+              10,
+              200
+            ],
+            [
+              18,
+              400
+            ]
+          ]
+        },
+        "text-field": "{ref}",
+        "text-font": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "motorway",
+          [
+            "literal",
+            [
+              "Roboto Bold",
+              "Noto Sans Bold"
+            ]
+          ],
+          [
+            "literal",
+            [
+              "Roboto Regular"
+            ]
+          ]
+        ],
+        "text-offset": [
+          0,
+          0.05
+        ],
+        "text-padding": 2,
+        "text-rotation-alignment": "viewport",
+        "text-size": 10,
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(0, 0%, 100%)",
+        "icon-halo-color": "hsl(0, 0%, 29%)",
+        "icon-halo-width": 1,
+        "text-color": "hsl(0, 0%, 29%)",
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 1
+      },
+      "filter": [
+        "all",
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "!in",
+          "network",
+          "us-interstate",
+          "us-highway",
+          "us-state"
+        ],
+        [
+          "!in",
+          "class",
+          "path"
+        ]
+      ]
+    },
+    {
+      "id": "Highway shield (US)",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 7,
+      "layout": {
+        "icon-image": "{network}_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1.1,
+        "symbol-avoid-edges": true,
+        "symbol-placement": {
+          "base": 1,
+          "stops": [
+            [
+              7,
+              "point"
+            ],
+            [
+              7,
+              "line"
+            ],
+            [
+              8,
+              "line"
+            ]
+          ]
+        },
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "motorway",
+          [
+            "literal",
+            [
+              "Roboto Bold",
+              "Noto Sans Bold"
+            ]
+          ],
+          [
+            "literal",
+            [
+              "Roboto Regular",
+              "Noto Sans Regular"
+            ]
+          ]
+        ],
+        "text-offset": [
+          0,
+          0.05
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 9,
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(0, 0%, 100%)",
+        "icon-halo-color": "hsl(0, 0%, 29%)",
+        "icon-halo-width": 1,
+        "text-color": "hsl(0, 0%, 29%)",
+        "text-halo-color": "rgba(255, 255, 255, 1)",
+        "text-halo-width": 0
+      },
+      "filter": [
+        "all",
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "network",
+          "us-highway",
+          "us-state"
+        ],
+        [
+          "!in",
+          "class",
+          "path"
+        ]
+      ]
+    },
+    {
+      "id": "Highway shield interstate top (US)",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 7,
+      "layout": {
+        "icon-image": "{network}_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-placement": {
+          "base": 1,
+          "stops": [
+            [
+              7,
+              "point"
+            ],
+            [
+              7,
+              "line"
+            ],
+            [
+              8,
+              "line"
+            ]
+          ]
+        },
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "motorway",
+          [
+            "literal",
+            [
+              "Roboto Bold",
+              "Noto Sans Bold"
+            ]
+          ],
+          [
+            "literal",
+            [
+              "Roboto Regular",
+              "Noto Sans Regular"
+            ]
+          ]
+        ],
+        "text-offset": [
+          0,
+          0.1
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 9,
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(21, 100%, 45%)",
+        "icon-halo-color": "rgba(255, 255, 255, 1)",
+        "icon-halo-width": 1,
+        "icon-translate": [
+          0,
+          -4
+        ],
+        "icon-translate-anchor": "viewport",
+        "text-color": "hsl(21, 100%, 45%)",
+        "text-halo-color": "rgba(255, 255, 255, 1)",
+        "text-halo-width": 0
+      },
+      "filter": [
+        "all",
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "network",
+          "us-interstate"
+        ],
+        [
+          "!in",
+          "class",
+          "path"
+        ]
+      ]
+    },
+    {
+      "id": "Highway shield interstate (US)",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "transportation_name",
+      "minzoom": 7,
+      "layout": {
+        "icon-image": "{network}_{ref_length}",
+        "icon-rotation-alignment": "viewport",
+        "icon-size": 1,
+        "symbol-placement": {
+          "base": 1,
+          "stops": [
+            [
+              7,
+              "point"
+            ],
+            [
+              7,
+              "line"
+            ],
+            [
+              8,
+              "line"
+            ]
+          ]
+        },
+        "symbol-spacing": 200,
+        "text-field": "{ref}",
+        "text-font": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "motorway",
+          [
+            "literal",
+            [
+              "Roboto Bold",
+              "Noto Sans Bold"
+            ]
+          ],
+          [
+            "literal",
+            [
+              "Roboto Regular",
+              "Noto Sans Regular"
+            ]
+          ]
+        ],
+        "text-offset": [
+          0,
+          0.1
+        ],
+        "text-rotation-alignment": "viewport",
+        "text-size": 9,
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(212, 79%, 42%)",
+        "icon-halo-color": "rgba(255, 255, 255, 1)",
+        "icon-halo-width": 1,
+        "text-color": "hsl(0, 0%, 100%)",
+        "text-halo-color": "rgba(255, 255, 255, 1)",
+        "text-halo-width": 0,
+        "text-translate": [
+          0,
+          -0.5
+        ]
+      },
+      "filter": [
+        "all",
+        [
+          "<=",
+          "ref_length",
+          6
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "==",
+          "network",
+          "us-interstate"
+        ],
+        [
+          "!in",
+          "class",
+          "path"
+        ]
+      ]
+    },
+    {
+      "id": "Public",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 16,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "atm",
+            "bank",
+            "bbq",
+            "cemetery",
+            "courthouse",
+            "drinking_water",
+            "fire_station",
+            "fountain",
+            "hairdresser",
+            "office",
+            "post",
+            "prison",
+            "recycling",
+            "shower",
+            "telephone",
+            "toilets",
+            "townhall",
+            "town_hall"
+          ],
+          [
+            "get",
+            "class"
+          ],
+          [
+            "case",
+            [
+              "has",
+              "class"
+            ],
+            "",
+            "dot"
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(51, 10%, 40%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "atm",
+              "bank",
+              "cemetery",
+              "courthouse",
+              "townhall",
+              "town_hall"
+            ],
+            1,
+            0
+          ],
+          17,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "atm",
+              "bank",
+              "cemetery",
+              "courthouse",
+              "fire_station",
+              "townhall",
+              "town_hall",
+              "post"
+            ],
+            1,
+            0
+          ],
+          18,
+          1
+        ],
+        "text-color": "hsl(51, 10%, 40%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "atm",
+              "bank",
+              "cemetery",
+              "courthouse",
+              "townhall",
+              "town_hall"
+            ],
+            1,
+            0
+          ],
+          17,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "atm",
+              "bank",
+              "cemetery",
+              "courthouse",
+              "fire_station",
+              "townhall",
+              "town_hall",
+              "post"
+            ],
+            1,
+            0
+          ],
+          18,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "atm",
+          "bank",
+          "bbq",
+          "cemetery",
+          "courthouse",
+          "drinking_water",
+          "fire_station",
+          "fountain",
+          "hairdresser",
+          "office",
+          "post",
+          "prison",
+          "recycling",
+          "shower",
+          "telephone",
+          "toilets",
+          "townhall",
+          "town_hall"
+        ]
+      ]
+    },
+    {
+      "id": "Sport",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 16,
+      "layout": {
+        "icon-image": [
+          "coalesce",
+          [
+            "image",
+            [
+              "get",
+              "subclass"
+            ]
+          ],
+          [
+            "image",
+            [
+              "get",
+              "class"
+            ]
+          ],
+          [
+            "image",
+            "dot"
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(129, 65%, 30%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "playground",
+              "pitch",
+              "stadium",
+              "sports_hall",
+              "swimming_pool"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(129, 65%, 30%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "playground",
+              "pitch",
+              "stadium",
+              "sports_hall",
+              "swimming_pool"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "american_football",
+          "athletics",
+          "archery",
+          "baseball",
+          "basketball",
+          "climbing",
+          "equestrian",
+          "fitness",
+          "fitness_centre",
+          "golf",
+          "motor",
+          "multi",
+          "playground",
+          "pitch",
+          "running",
+          "sauna",
+          "soccer",
+          "sport",
+          "stadium",
+          "sports_centre",
+          "sports_hall",
+          "swimming",
+          "swimming_area",
+          "swimming_pool",
+          "tennis",
+          "volleyball",
+          "water_park"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Education",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 15,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "college",
+            "childcare",
+            "dancing_school",
+            "driving_school",
+            "kindergarten",
+            "school",
+            "university"
+          ],
+          [
+            "get",
+            "class"
+          ],
+          [
+            "case",
+            [
+              "has",
+              "class"
+            ],
+            "",
+            "dot"
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(175, 50%, 40%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          15,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "university"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "school",
+              "university"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(175, 50%, 40%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          15,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "university"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "school",
+              "university"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "college",
+          "childcare",
+          "dancing_school",
+          "driving_school",
+          "kindergarten",
+          "school",
+          "university"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Tourism",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "apartment",
+            "aquarium",
+            "attraction",
+            "campsite",
+            "camp_site",
+            "caravan_site",
+            "castle",
+            "chalet",
+            "guest_house",
+            "hotel",
+            "hostel",
+            "information",
+            "lodging",
+            "motel",
+            "reservoir",
+            "ruins",
+            "theme_park",
+            "zoo"
+          ],
+          [
+            "get",
+            "class"
+          ],
+          [
+            "case",
+            [
+              "has",
+              "class"
+            ],
+            "",
+            "dot"
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(283, 55%, 35%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "attraction"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "attraction",
+              "castle",
+              "hotel",
+              "zoo"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(283, 55%, 35%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "attraction"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "attraction",
+              "castle",
+              "hotel",
+              "zoo"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "apartment",
+          "aquarium",
+          "attraction",
+          "campsite",
+          "camp_site",
+          "caravan_site",
+          "castle",
+          "chalet",
+          "guest_house",
+          "hotel",
+          "hostel",
+          "information",
+          "lodging",
+          "motel",
+          "reservoir",
+          "ruins",
+          "theme_park",
+          "zoo"
+        ],
+        [
+          "!=",
+          "subclass",
+          "board"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Culture",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "layout": {
+        "icon-image": [
+          "coalesce",
+          [
+            "image",
+            [
+              "get",
+              "subclass"
+            ]
+          ],
+          [
+            "image",
+            [
+              "get",
+              "class"
+            ]
+          ],
+          [
+            "image",
+            "dot"
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(315, 35%, 50%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "museum"
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "cinema",
+              "art_gallery",
+              "museum",
+              "theatre"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "cinema",
+              "art_gallery",
+              "library",
+              "museum",
+              "place_of_worship",
+              "theatre"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(315, 35%, 50%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "museum"
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "cinema",
+              "art_gallery",
+              "museum",
+              "theatre"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "cinema",
+              "art_gallery",
+              "library",
+              "museum",
+              "place_of_worship",
+              "theatre"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "art_gallery",
+          "archeological_site",
+          "cinema",
+          "community_centre",
+          "gallery",
+          "library",
+          "monastery",
+          "monument",
+          "museum",
+          "opera",
+          "place_of_worship",
+          "planetarium",
+          "theatre"
+        ],
+        [
+          "!=",
+          "subclass",
+          "artwork"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Shopping",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "layout": {
+        "icon-image": [
+          "coalesce",
+          [
+            "image",
+            [
+              "get",
+              "subclass"
+            ]
+          ],
+          [
+            "image",
+            [
+              "get",
+              "class"
+            ]
+          ],
+          [
+            "image",
+            "dot"
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(18, 17%, 30%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "mall"
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "mall",
+              "supermarket"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "bakery",
+              "chemist",
+              "mall",
+              "supermarket"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(18, 17%, 30%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "mall"
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "mall",
+              "supermarket"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "bakery",
+              "chemist",
+              "mall",
+              "supermarket"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "all",
+          [
+            "in",
+            "class",
+            "alcohol_shop",
+            "bakery",
+            "book",
+            "books",
+            "butcher",
+            "chemist",
+            "clothing_store",
+            "convenience",
+            "gift",
+            "grocery",
+            "laundry",
+            "mall",
+            "music",
+            "shop",
+            "supermarket"
+          ],
+          [
+            "has",
+            "name"
+          ]
+        ]
+      ]
+    },
+    {
+      "id": "Food",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "maxzoom": 22,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "bar",
+            "beer",
+            "cafe",
+            "fast_food",
+            "ice_cream",
+            "restaurant"
+          ],
+          [
+            "get",
+            "class"
+          ],
+          [
+            "biergarten",
+            "pub"
+          ],
+          "beer",
+          "",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "food_court"
+          ],
+          "restaurant",
+          "dot"
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(18, 24%, 44%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              20
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              99
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              499
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(18, 24%, 44%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              20
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              99
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              499
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "bar",
+          "beer",
+          "biergarten",
+          "cafe",
+          "fast_food",
+          "food_court",
+          "ice_cream",
+          "pub",
+          "restaurant"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Transport",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "aerialway",
+            "bicycle",
+            "bicycle_parking",
+            "car",
+            "car_rental",
+            "car_repair",
+            "charging_station",
+            "cycle_barrier",
+            "ferry_terminal",
+            "fuel",
+            "harbor",
+            "motorcycle_parking",
+            "parking",
+            "parking_garage",
+            "parking_paid"
+          ],
+          [
+            "get",
+            "class"
+          ],
+          [
+            "case",
+            [
+              "has",
+              "class"
+            ],
+            "dot",
+            ""
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(215, 81%, 35%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "ferry_terminal",
+              "fuel",
+              "terminal"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "car",
+              "car_rental",
+              "car_repair",
+              "charging_station",
+              "ferry_terminal",
+              "fuel",
+              "harbor",
+              "heliport",
+              "highway_rest_area",
+              "terminal",
+              "toll"
+            ],
+            1,
+            0
+          ],
+          17,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "car",
+              "car_rental",
+              "car_repair",
+              "charging_station",
+              "ferry_terminal",
+              "fuel",
+              "harbor",
+              "heliport",
+              "highway_rest_area",
+              "parking",
+              "parking_garage",
+              "parking_paid",
+              "terminal",
+              "toll"
+            ],
+            1,
+            0
+          ],
+          18,
+          1
+        ],
+        "text-color": "hsl(215, 81%, 35%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "ferry_terminal",
+              "fuel",
+              "terminal"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "car",
+              "car_rental",
+              "car_repair",
+              "charging_station",
+              "ferry_terminal",
+              "fuel",
+              "harbor",
+              "heliport",
+              "highway_rest_area",
+              "terminal",
+              "toll"
+            ],
+            1,
+            0
+          ],
+          17,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "car",
+              "car_rental",
+              "car_repair",
+              "charging_station",
+              "ferry_terminal",
+              "fuel",
+              "harbor",
+              "heliport",
+              "highway_rest_area",
+              "parking",
+              "parking_garage",
+              "parking_paid",
+              "terminal",
+              "toll"
+            ],
+            1,
+            0
+          ],
+          18,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "bicycle",
+          "bicycle_parking",
+          "bicycle_rental",
+          "car",
+          "car_rental",
+          "car_repair",
+          "charging_station",
+          "ferry_terminal",
+          "fuel",
+          "harbor",
+          "heliport",
+          "highway_rest_area",
+          "motorcycle_parking",
+          "parking",
+          "parking_garage",
+          "parking_paid",
+          "scooter",
+          "terminal",
+          "toll"
+        ]
+      ]
+    },
+    {
+      "id": "Park",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "layout": {
+        "icon-anchor": "center",
+        "icon-image": "park",
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(82, 83%, 25%)",
+        "icon-halo-blur": 0,
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              10
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              99
+            ],
+            1,
+            0
+          ],
+          16,
+          1
+        ],
+        "text-color": "hsl(82, 83%, 25%)",
+        "text-halo-blur": 0,
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              10
+            ],
+            1,
+            0
+          ],
+          15,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              99
+            ],
+            1,
+            0
+          ],
+          16,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "park"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Healthcare",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 14,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "clinic",
+            "dentist",
+            "doctors",
+            "doctor",
+            "first_aid",
+            "hospital",
+            "pharmacy",
+            "veterinary"
+          ],
+          [
+            "get",
+            "class"
+          ],
+          [
+            "case",
+            [
+              "has",
+              "class"
+            ],
+            "",
+            "dot"
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              12,
+              10
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(6, 96%, 35%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "hospital"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "clinic",
+              "hospital"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(6, 96%, 35%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "hospital"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "clinic",
+              "hospital"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "in",
+          "class",
+          "clinic",
+          "dentist",
+          "doctors",
+          "first_aid",
+          "hospital",
+          "pharmacy",
+          "veterinary"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Place labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "place",
+      "minzoom": 4,
+      "layout": {
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "center",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-letter-spacing": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "suburb",
+            "neighborhood",
+            "neighbourhood",
+            "quarter",
+            "island"
+          ],
+          0.2,
+          0
+        ],
+        "text-max-width": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "island"
+          ],
+          6,
+          8
+        ],
+        "text-offset": [
+          0,
+          0
+        ],
+        "text-padding": 2,
+        "text-size": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          3,
+          11,
+          8,
+          13,
+          11,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            "village",
+            12,
+            [
+              "suburb",
+              "neighbourhood",
+              "quarter",
+              "hamlet",
+              "isolated_dwelling"
+            ],
+            9,
+            "island",
+            8,
+            12
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            "village",
+            18,
+            [
+              "suburb",
+              "neighbourhood",
+              "quarter",
+              "hamlet",
+              "isolated_dwelling"
+            ],
+            15,
+            "island",
+            11,
+            16
+          ]
+        ],
+        "text-transform": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          [
+            "suburb",
+            "neighborhood",
+            "neighbourhood",
+            "quarter",
+            "island"
+          ],
+          "uppercase",
+          "none"
+        ],
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(0,0%,25%)",
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1.2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          1,
+          8,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "island"
+            ],
+            0,
+            1
+          ],
+          9,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            [
+              "island"
+            ],
+            1,
+            1
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "!in",
+        "class",
+        "continent",
+        "country",
+        "state",
+        "region",
+        "province",
+        "city",
+        "town",
+        "place"
+      ]
+    },
+    {
+      "id": "Station",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "poi",
+      "minzoom": 12,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "subclass"
+          ],
+          [
+            "bus_stop",
+            "subway"
+          ],
+          [
+            "get",
+            "subclass"
+          ],
+          "bus_station",
+          "bus_stop",
+          "station",
+          "railway",
+          "tram_stop",
+          "tramway",
+          [
+            "case",
+            [
+              "has",
+              "subclass"
+            ],
+            "dot",
+            ""
+          ]
+        ],
+        "icon-size": 1,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-line-height": 0.9,
+        "text-max-width": 9,
+        "text-offset": [
+          0,
+          0.9
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              13,
+              11
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              22,
+              16
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(215, 83%, 53%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.8,
+          16,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": 2,
+        "icon-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          12,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "station"
+            ],
+            1,
+            0
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "station",
+              "subway",
+              "tram_stop"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "bus_stop",
+              "station",
+              "subway",
+              "tram_stop"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ],
+        "text-color": "hsl(215, 83%, 53%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          12,
+          1,
+          14,
+          0.5,
+          16,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": 2,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          12,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "station"
+            ],
+            1,
+            0
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "station",
+              "subway",
+              "tram_stop"
+            ],
+            1,
+            0
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "subclass"
+            ],
+            [
+              "bus_stop",
+              "station",
+              "subway",
+              "tram_stop"
+            ],
+            1,
+            0
+          ],
+          17,
+          1
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "bus",
+          "railway"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ]
+    },
+    {
+      "id": "Airport gate",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "aeroway",
+      "minzoom": 15,
+      "layout": {
+        "text-field": "{ref}",
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-size": {
+          "stops": [
+            [
+              15,
+              10
+            ],
+            [
+              22,
+              18
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(0,0%,40%)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1
+      },
+      "filter": [
+        "==",
+        "class",
+        "gate"
+      ]
+    },
+    {
+      "id": "Airport",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "aerodrome_label",
+      "minzoom": 8,
+      "layout": {
+        "icon-image": [
+          "match",
+          [
+            "get",
+            "class"
+          ],
+          "international",
+          "airport",
+          "airfield"
+        ],
+        "icon-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8,
+          0.6,
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            "international",
+            0.8,
+            0.6
+          ],
+          16,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            "international",
+            1,
+            0.8
+          ]
+        ],
+        "text-anchor": "top",
+        "text-field": {
+          "stops": [
+            [
+              8,
+              " "
+            ],
+            [
+              9,
+              "{iata}"
+            ],
+            [
+              12,
+              "{name:en}"
+            ]
+          ]
+        },
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-line-height": 1.2,
+        "text-max-width": 9,
+        "text-offset": [
+          0,
+          0.8
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          9,
+          9,
+          10,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            "international",
+            10,
+            7
+          ],
+          14,
+          [
+            "match",
+            [
+              "get",
+              "class"
+            ],
+            "international",
+            13,
+            11
+          ]
+        ],
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(215, 83%, 53%)",
+        "icon-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8,
+          1,
+          10,
+          0.5,
+          12,
+          0
+        ],
+        "icon-halo-color": "hsl(0, 0%, 100%)",
+        "icon-halo-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8,
+          1,
+          12,
+          2
+        ],
+        "icon-opacity": 1,
+        "text-color": "hsl(215, 83%, 53%)",
+        "text-halo-blur": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8,
+          1,
+          10,
+          0.5,
+          12,
+          0
+        ],
+        "text-halo-color": "hsl(0, 0%, 100%)",
+        "text-halo-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          8,
+          1,
+          12,
+          2
+        ]
+      },
+      "filter": [
+        "all",
+        [
+          "has",
+          "iata"
+        ],
+        [
+          "!in",
+          "class",
+          "public"
+        ]
+      ]
+    },
+    {
+      "id": "State labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "place",
+      "minzoom": 3,
+      "maxzoom": 9,
+      "layout": {
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-letter-spacing": 0.1,
+        "text-max-width": 8,
+        "text-padding": 2,
+        "text-size": {
+          "stops": [
+            [
+              3,
+              9
+            ],
+            [
+              5,
+              10
+            ],
+            [
+              6,
+              11
+            ]
+          ]
+        },
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(48,4%,44%)",
+        "text-halo-color": "hsla(0,0%,100%,0.75)",
+        "text-halo-width": 0.8,
+        "text-opacity": [
+          "step",
+          [
+            "zoom"
+          ],
+          0,
+          3,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              3
+            ],
+            1,
+            0
+          ],
+          8,
+          [
+            "case",
+            [
+              "==",
+              [
+                "get",
+                "rank"
+              ],
+              0
+            ],
+            0,
+            1
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "state",
+          "province"
+        ],
+        [
+          "<=",
+          "rank",
+          6
+        ]
+      ]
+    },
+    {
+      "id": "Town labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "place",
+      "minzoom": 4,
+      "maxzoom": 16,
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-image": {
+          "stops": [
+            [
+              6,
+              "circle"
+            ],
+            [
+              12,
+              " "
+            ]
+          ]
+        },
+        "icon-optional": false,
+        "icon-size": [
+          "interpolate",
+          [
+            "exponential",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          0.3,
+          14,
+          0.4
+        ],
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "bottom",
+        "text-field": [
+          "coalesce",
+          [
+            "get",
+            "name:en"
+          ],
+          [
+            "get",
+            "name"
+          ]
+        ],
+        "text-font": [
+          "Roboto Regular",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          -0.15
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              12
+            ],
+            11,
+            10
+          ],
+          9,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              15
+            ],
+            13,
+            12
+          ],
+          16,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              15
+            ],
+            22,
+            20
+          ]
+        ],
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(0, 20%, 99%)",
+        "icon-halo-color": "hsl(0, 0%, 29%)",
+        "icon-halo-width": 1,
+        "text-color": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          6,
+          "hsl(0,0%,20%)",
+          12,
+          "hsl(0,0%,0%)"
+        ],
+        "text-halo-blur": 0.5,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "class",
+        "town"
+      ]
+    },
+    {
+      "id": "City labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "place",
+      "minzoom": 4,
+      "maxzoom": 16,
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-image": [
+          "step",
+          [
+            "zoom"
+          ],
+          "circle",
+          13,
+          ""
+        ],
+        "icon-optional": false,
+        "icon-size": 0.4,
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "bottom",
+        "text-field": "{name:en}",
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          -0.15
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          4,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              2
+            ],
+            14,
+            12
+          ],
+          8,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              4
+            ],
+            18,
+            14
+          ],
+          12,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              4
+            ],
+            24,
+            18
+          ],
+          16,
+          [
+            "case",
+            [
+              "<=",
+              [
+                "get",
+                "rank"
+              ],
+              4
+            ],
+            32,
+            26
+          ]
+        ],
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(0, 0%, 100%)",
+        "icon-halo-color": "hsl(0, 0%, 29%)",
+        "icon-halo-width": 1,
+        "icon-opacity": 1,
+        "text-color": "hsl(0,0%,20%)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 0.8
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "!=",
+          "capital",
+          2
+        ]
+      ]
+    },
+    {
+      "id": "Capital city labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "place",
+      "minzoom": 4,
+      "maxzoom": 16,
+      "layout": {
+        "icon-allow-overlap": true,
+        "icon-image": [
+          "step",
+          [
+            "zoom"
+          ],
+          "circle",
+          13,
+          ""
+        ],
+        "icon-optional": false,
+        "icon-size": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          4,
+          0.45,
+          10,
+          0.5,
+          11,
+          0.6
+        ],
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-anchor": "bottom",
+        "text-field": "{name:en}",
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 8,
+        "text-offset": [
+          0,
+          -0.15
+        ],
+        "text-size": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          4,
+          14,
+          8,
+          18,
+          12,
+          24,
+          16,
+          32
+        ],
+        "visibility": "visible"
+      },
+      "paint": {
+        "icon-color": "hsl(0, 0%, 100%)",
+        "icon-halo-color": "hsl(0, 0%, 29%)",
+        "icon-halo-width": 1,
+        "icon-opacity": 1,
+        "text-color": "hsl(0,0%,20%)",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 0.8
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "==",
+          "capital",
+          2
+        ]
+      ]
+    },
+    {
+      "id": "Country labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "place",
+      "minzoom": 1,
+      "maxzoom": 12,
+      "layout": {
+        "symbol-sort-key": [
+          "to-number",
+          [
+            "get",
+            "rank"
+          ]
+        ],
+        "text-allow-overlap": false,
+        "text-field": "{name:en}",
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-letter-spacing": 0.07,
+        "text-max-width": {
+          "stops": [
+            [
+              1,
+              5
+            ],
+            [
+              5,
+              8
+            ]
+          ]
+        },
+        "text-padding": 1,
+        "text-size": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          0,
+          8,
+          1,
+          10,
+          4,
+          [
+            "case",
+            [
+              ">",
+              [
+                "get",
+                "rank"
+              ],
+              2
+            ],
+            15,
+            17
+          ],
+          8,
+          [
+            "case",
+            [
+              ">",
+              [
+                "get",
+                "rank"
+              ],
+              2
+            ],
+            19,
+            23
+          ]
+        ],
+        "text-transform": "none",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(0, 0%, 20%)",
+        "text-halo-blur": 0.8,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1,
+        "text-opacity": [
+          "interpolate",
+          [
+            "linear",
+            1
+          ],
+          [
+            "zoom"
+          ],
+          4,
+          [
+            "case",
+            [
+              ">",
+              [
+                "get",
+                "rank"
+              ],
+              4
+            ],
+            0,
+            1
+          ],
+          5.9,
+          [
+            "case",
+            [
+              ">",
+              [
+                "get",
+                "rank"
+              ],
+              4
+            ],
+            0,
+            1
+          ],
+          6,
+          [
+            "case",
+            [
+              ">",
+              [
+                "get",
+                "rank"
+              ],
+              4
+            ],
+            1,
+            1
+          ]
+        ]
+      },
+      "metadata": {},
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "country"
+        ],
+        [
+          "has",
+          "iso_a2"
+        ],
+        [
+          "!=",
+          "iso_a2",
+          "VA"
+        ]
+      ]
+    },
+    {
+      "id": "Continent labels",
+      "type": "symbol",
+      "source": "maptiler_planet",
+      "source-layer": "place",
+      "maxzoom": 1,
+      "layout": {
+        "text-field": "{name:en}",
+        "text-font": [
+          "Roboto Medium",
+          "Noto Sans Regular"
+        ],
+        "text-justify": "center",
+        "text-size": {
+          "stops": [
+            [
+              0,
+              12
+            ],
+            [
+              2,
+              13
+            ]
+          ]
+        },
+        "text-transform": "uppercase",
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "hsl(0,0%,19%)",
+        "text-halo-blur": 1,
+        "text-halo-color": "hsl(0,0%,100%)",
+        "text-halo-width": 1
+      },
+      "metadata": {},
+      "filter": [
+        "==",
+        "class",
+        "continent"
+      ]
+    }
+  ],
+  "metadata": {
+    "maptiler:copyright": "You are licensed to use the style or its derivate for serving map tiles exclusively with MapTiler Server or MapTiler Cloud and in accordance with their licenses and terms. If you plan to use the style in a different way, contact us at sales@maptiler.com.",
+    "spaceColor": "hsl(203, 100%, 85%)"
+  },
+  "glyphs": "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key=MZEJTanw3WpxRvt7qDfo",
+  "sprite": "https://api.maptiler.com/maps/streets-v2/sprite",
+  "bearing": 0,
+  "pitch": 0,
+  "center": [
+    0,
+    0
+  ],
+  "zoom": 1,
+  "light": {
+    "anchor": "viewport",
+    "color": "#FFFFFF",
+    "intensity": 0.5,
+    "position": [
+      1.15,
+      180,
+      0
+    ]
+  }
+}

--- a/web/assets/map-styles/streets-v2-style.json
+++ b/web/assets/map-styles/streets-v2-style.json
@@ -2463,7 +2463,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "hsl(48,100%,83%)",
+        "line-color": "hsl(0, 0%, 50%)",
         "line-width": [
           "interpolate",
           [
@@ -2576,7 +2576,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "hsl(35,100%,76%)",
+        "line-color": "hsl(0, 0%, 50%)",
         "line-width": [
           "interpolate",
           [

--- a/web/assets/map-styles/streets-v2-style.json
+++ b/web/assets/map-styles/streets-v2-style.json
@@ -1792,7 +1792,7 @@
         "visibility": "visible"
       },
       "paint": {
-        "line-color": "hsl(28,72%,69%)",
+        "line-color": "hsl(0,0%,20%)",
         "line-opacity": 1,
         "line-width": [
           "interpolate",
@@ -2336,11 +2336,6 @@
               "class"
             ],
             [
-              "secondary",
-              "tertiary"
-            ],
-            1.5,
-            [
               "minor",
               "service",
               "track"
@@ -2355,14 +2350,6 @@
               "get",
               "class"
             ],
-            [
-              "secondary"
-            ],
-            4,
-            [
-              "tertiary"
-            ],
-            3,
             [
               "minor",
               "service",
@@ -2379,14 +2366,6 @@
               "class"
             ],
             [
-              "secondary"
-            ],
-            7,
-            [
-              "tertiary"
-            ],
-            6,
-            [
               "minor",
               "service",
               "track"
@@ -2401,14 +2380,6 @@
               "get",
               "class"
             ],
-            [
-              "secondary"
-            ],
-            24,
-            [
-              "tertiary"
-            ],
-            24,
             [
               "minor",
               "service",
@@ -2441,6 +2412,13 @@
           "pier",
           "primary",
           "primary_construction",
+          "primary_link",
+          "trunk",
+          "trunk_link",
+          "secondary",
+          "secondary_link",
+          "tertiary",
+          "tertiary_link",
           "rail",
           "secondary_construction",
           "service_construction",
@@ -2560,7 +2538,13 @@
           "in",
           "class",
           "primary",
-          "trunk"
+          "primary_link",
+          "trunk",
+          "trunk_link",
+          "secondary",
+          "secondary_link",
+          "tertiary",
+          "tertiary_link"
         ]
       ]
     },

--- a/web/assets/map-styles/streets-v2-style.json
+++ b/web/assets/map-styles/streets-v2-style.json
@@ -3127,7 +3127,6 @@
       "source": "maptiler_planet",
       "source-layer": "building",
       "minzoom": 13,
-      "maxzoom": 15,
       "layout": {
         "visibility": "visible"
       },
@@ -3149,33 +3148,6 @@
         }
       },
       "metadata": {}
-    },
-    {
-      "id": "Building 3D",
-      "type": "fill-extrusion",
-      "source": "maptiler_planet",
-      "source-layer": "building",
-      "minzoom": 15,
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "fill-extrusion-base": {
-          "property": "render_min_height",
-          "type": "identity"
-        },
-        "fill-extrusion-color": "hsl(44,14%,79%)",
-        "fill-extrusion-height": {
-          "property": "render_height",
-          "type": "identity"
-        },
-        "fill-extrusion-opacity": 0.4
-      },
-      "metadata": {},
-      "filter": [
-        "!has",
-        "hide_3d"
-      ]
     },
     {
       "id": "Aqueduct outline",

--- a/web/assets/map-styles/streets-v2-style.json
+++ b/web/assets/map-styles/streets-v2-style.json
@@ -3131,18 +3131,18 @@
         "visibility": "visible"
       },
       "paint": {
-        "fill-color": "hsl(30,6%,73%)",
-        "fill-opacity": 0.3,
+        "fill-color": "hsla(30, 6%, 50%)",
+        "fill-opacity": 0.4,
         "fill-outline-color": {
           "base": 1,
           "stops": [
             [
               13,
-              "hsla(35, 6%, 79%, 0.3)"
+              "hsla(35, 6%, 50%, 0.2)"
             ],
             [
               14,
-              "hsl(35, 6%, 79%)"
+              "hsla(35, 6%, 50%, 1.0)"
             ]
           ]
         }

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -24,6 +24,7 @@
     sidebarContents,
     topContents,
   } from "svelte-utils/top_bar_layout";
+  import streetsMapStyleUrl from "../assets/map-styles/streets-v2-style.json?url";
   import AutoBoundariesMode from "./AutoBoundariesMode.svelte";
   import { DisableInteractiveLayers, layerId, StreetView } from "./common";
   import DebugDemandMode from "./DebugDemandMode.svelte";
@@ -102,20 +103,13 @@
   async function getStyle(
     basemap: string,
   ): Promise<StyleSpecification | string> {
-    if (basemap != "streets-v2") {
+    // streets-v2 uses a fill-extrusion layer for 3D buildings that's very distracting, so we have a custom version
+    // NOTE: our maptiler apiKey is baked into the downloaded style, so if we rotate keys, we'll need to regenerate this file.
+    if (basemap == "streets-v2") {
+      return streetsMapStyleUrl;
+    } else {
       return `https://api.maptiler.com/maps/${basemap}/style.json?key=${maptilerApiKey}`;
     }
-
-    // streets-v2 uses a fill-extrusion layer for 3D buildings that's very distracting. Remove it, and make the regular buildings layer display at high zoom instead.
-    let resp = await fetch(
-      `https://api.maptiler.com/maps/${basemap}/style.json?key=${maptilerApiKey}`,
-    );
-    let json = await resp.json();
-
-    json.layers = json.layers.filter((l: any) => l.id != "Building 3D");
-    delete json.layers.find((l: any) => l.id == "Building")!.maxzoom;
-
-    return json;
   }
 </script>
 

--- a/web/src/layers/CellLayer.svelte
+++ b/web/src/layers/CellLayer.svelte
@@ -12,7 +12,8 @@
   }}
   paint={{
     "fill-color": ["get", "color"],
-    "fill-opacity": 0.8,
+    "fill-opacity": 0.5,
+    "fill-outline-color": "hsla(0, 0%, 0%, 0.3)",
   }}
 />
 

--- a/web/src/stores.ts
+++ b/web/src/stores.ts
@@ -9,6 +9,7 @@ import { type AreaProps } from "route-snapper-ts";
 import { get, writable, type Writable } from "svelte/store";
 import type { Backend } from "./wasm";
 
+// NOTE: our maptiler apiKey is baked into the customized assets/map-styles/, so if we rotate keys, we'll need to update that file too.
 export const maptilerApiKey = "MZEJTanw3WpxRvt7qDfo";
 
 export type Mode =


### PR DESCRIPTION
FIXES #198 and a followup item mentioned in #220

Really, we could merge any subset of these commits. I tried to keep them separable.

Apart from the individual design changes, the big structural change is that I've vendored the maptiler style. 

Alternatively we could continue with the previous pattern of downloading and post-processing the given style, but as our diversions get more complex, it becomes increasingly hard to reason about. There's a reason these style files are declarative! 

I also think that it's totally reasonable that we are starting to develop our own cartography - the needs of our app are  special, and unique from some platonic "general purpose map".

## Screenshots 

**before:**

<img width="1624" alt="Screenshot 2025-03-11 at 13 24 22" src="https://github.com/user-attachments/assets/2d09d687-168f-4c03-8559-a3c53b7becde" />

**after:** "main" roads are gray

<img width="1580" alt="Screenshot 2025-03-11 at 13 24 52" src="https://github.com/user-attachments/assets/a38f6336-2052-473e-999b-cb8612ad6591" />

**before:**

<img width="1624" alt="Screenshot 2025-03-11 at 13 24 32" src="https://github.com/user-attachments/assets/df36c1a8-7f1c-476e-9c7a-6ea9c20a7e61" />

**after:**  most notable here is the relative building and cell contrast

<img width="1624" alt="Screenshot 2025-03-11 at 13 24 58" src="https://github.com/user-attachments/assets/595f1586-0f55-4150-a2df-1d7c8dc1f24c" />

**before:**

<img width="1624" alt="Screenshot 2025-03-11 at 13 24 40" src="https://github.com/user-attachments/assets/4de92601-de5b-4aff-853b-d75d21f6c278" />


**after:** most notable here is the relative building and cell contrast

<img width="1580" alt="Screenshot 2025-03-11 at 13 25 21" src="https://github.com/user-attachments/assets/ea771ee1-8a9d-4a2f-8fc0-c0d2477ee312" />



