### PR TITLE
unify/style project listing

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -328,4 +328,66 @@
     font-weight: bold;
     text-decoration: underline;
   }
+
+  /**
+  * Gloal Typography
+  */
+
+  :global(.left .pico h1) {
+    font-size: 36px;
+    margin: 0 0 10px 0;
+  }
+
+  :global(.left .pico h2) {
+    font-size: 28px;
+    margin: 0 0 8px 0;
+  }
+
+  :global(.left .pico h3) {
+    font-size: 22px;
+    margin: 0 0 6px 0;
+  }
+
+  :global(.left .pico h4) {
+    font-size: 18px;
+    margin: 0 0 4px 0;
+  }
+
+  /**
+  * List navigation re-used for neighbourhood and project list
+  */
+  :global(.left .pico .navigable-list h1),
+  :global(.left .pico .navigable-list h2),
+  :global(.left .pico .navigable-list h3),
+  :global(.left .pico .navigable-list h4) {
+    padding: 0;
+    margin: 0;
+  }
+
+  :global(ul.navigable-list) {
+    padding: 0;
+    margin-bottom: 16px;
+  }
+
+  :global(.navigable-list > li) {
+    list-style: none;
+    margin: 0;
+    padding: 8px 8px;
+  }
+
+  :global(.navigable-list > li:not(:last-child)) {
+    border-bottom: solid #ddd 1px;
+  }
+
+  :global(.left .pico .navigable-list .actionable-cell) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  :global(.left .pico .navigable-list .actionable-cell .actions) {
+    display: flex;
+    gap: 16px;
+  }
 </style>

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -259,6 +259,15 @@
 </div>
 
 <style>
+  :global(#app .left) {
+    width: 35%;
+    min-width: 400px;
+    max-width: 700px;
+  }
+  :global(#app .main) {
+    width: 65%;
+  }
+
   :global(.pico .icon-btn.destructive),
   :global(.icon-btn.destructive) {
     background-color: #dc2626;

--- a/web/src/CntChooseArea.svelte
+++ b/web/src/CntChooseArea.svelte
@@ -12,9 +12,7 @@
   import boundariesUrl from "../assets/cnt_boundaries.geojson?url";
   import { Link } from "./common";
   import { createNewProject } from "./title/loader";
-  import LoadSavedProject from "./title/LoadSavedProject.svelte";
 
-  export let loadProject: (project: string) => void;
   export let activityIndicatorText: string;
 
   let gj: FeatureCollection<
@@ -65,28 +63,6 @@
       }
     }
   }
-
-  // Returns boundary => list of filenames
-  function listAllFiles(): Map<string, string[]> {
-    let map = new Map();
-    for (let i = 0; i < window.localStorage.length; i++) {
-      let key = window.localStorage.key(i)!;
-      if (key.startsWith("ltn_cnt/")) {
-        try {
-          let [_, boundary, filename] = key.split("/");
-          if (!map.has(boundary)) {
-            map.set(boundary, []);
-          }
-          map.get(boundary).push(filename);
-        } catch (_) {}
-      }
-    }
-
-    for (let list of map.values()) {
-      list.sort();
-    }
-    return map;
-  }
 </script>
 
 <p>Choose a boundary below or on the map to begin sketching:</p>
@@ -95,29 +71,6 @@
     <li><Link on:click={() => newFile(`LAD_${name}`)}>{name}</Link></li>
   {/each}
 </ul>
-
-<!-- 
-<hr />
-<p>Or continue with a previously opened file:</p>
-
-<div style="columns: 2">
-  {#each listAllFiles() as [boundary, projectNames]}
-    <div class="group">
-      <h2>{boundary}</h2>
-      {#each projectNames as projectName}
-        <p>
-          <Link
-            on:click={() => loadProject(`ltn_cnt/${boundary}/${projectName}`)}
-          >
-            {projectName}
-          </Link>
-        </p>
-      {/each}
-    </div>
-  {/each}
-</div> 
-<LoadSavedProject bind:loading={activityIndicatorText} /> 
--->
 
 <GeoJSON data={gj} generateId>
   <FillLayer
@@ -145,12 +98,3 @@
     manageHoverState
   />
 </GeoJSON>
-
-<style>
-  .group {
-    border: 1px solid black;
-    padding: 4px;
-    margin-bottom: 8px;
-    break-inside: avoid-column;
-  }
-</style>

--- a/web/src/CntChooseArea.svelte
+++ b/web/src/CntChooseArea.svelte
@@ -96,8 +96,8 @@
   {/each}
 </ul>
 
+<!-- 
 <hr />
-
 <p>Or continue with a previously opened file:</p>
 
 <div style="columns: 2">
@@ -115,9 +115,9 @@
       {/each}
     </div>
   {/each}
-</div>
-
-<LoadSavedProject bind:loading={activityIndicatorText} />
+</div> 
+<LoadSavedProject bind:loading={activityIndicatorText} /> 
+-->
 
 <GeoJSON data={gj} generateId>
   <FillLayer

--- a/web/src/CntChooseArea.svelte
+++ b/web/src/CntChooseArea.svelte
@@ -85,7 +85,7 @@
     on:click={onClick}
   >
     <Popup openOn="hover" let:props>
-      <p>{props.name}</p>
+      <p>Click to start a new project in {props.name}</p>
     </Popup>
   </FillLayer>
 

--- a/web/src/PickNeighbourhoodMode.svelte
+++ b/web/src/PickNeighbourhoodMode.svelte
@@ -225,36 +225,31 @@
   </div>
 
   <div slot="sidebar">
-    <h3 style="padding: 4px 8px; margin-bottom: 0">Neighbourhoods</h3>
-    <ul class="neighbourhood-list">
+    <h2>Neighbourhoods</h2>
+    <ul class="navigable-list">
       {#each neighbourhoods.features as { properties: { name } }}
         <li
           on:mouseenter={() => (hoveredNeighbourhoodFromList = name)}
           on:mouseleave={() => (hoveredNeighbourhoodFromList = null)}
+          class="actionable-cell"
           class:highlighted={hoveredMapFeature?.properties.name == name}
         >
-          <span style="display: flex; justify-content: space-between;">
-            <span class="neighbourhood-name">
-              <Link on:click={() => pickNeighbourhood(name)}>
-                {name}
-              </Link>
-            </span>
-            <span style="display: flex; gap: 16px;">
-              <button
-                class="outline icon-btn"
-                aria-label="Rename neighbourhood"
-                on:click={() => renameNeighbourhood(name)}
-              >
-                <Pencil color="black" />
-              </button>
-              <button
-                class="icon-btn destructive"
-                aria-label="Delete neighbourhood"
-                on:click={() => deleteNeighbourhood(name)}
-              >
-                <Trash2 color="white" />
-              </button>
-            </span>
+          <h3><Link on:click={() => pickNeighbourhood(name)}>{name}</Link></h3>
+          <span class="actions">
+            <button
+              class="outline icon-btn"
+              aria-label="Rename neighbourhood"
+              on:click={() => renameNeighbourhood(name)}
+            >
+              <Pencil color="black" />
+            </button>
+            <button
+              class="icon-btn destructive"
+              aria-label="Delete neighbourhood"
+              on:click={() => deleteNeighbourhood(name)}
+            >
+              <Trash2 color="white" />
+            </button>
           </span>
         </li>
       {/each}
@@ -349,28 +344,7 @@
 </SplitComponent>
 
 <style>
-  ul.neighbourhood-list {
-    padding: 0px;
-  }
-
-  ul.neighbourhood-list > li {
-    list-style: none;
-    margin: 0;
-    padding: 16px 8px;
-
-    display: flex;
-    flex-direction: column;
-    align-items: leading;
-    width: 100%;
-    border-bottom: solid #ddd 1px;
-  }
-
-  ul.neighbourhood-list > li.highlighted {
+  li.highlighted {
     background-color: #f0fcaa;
-  }
-
-  ul.neighbourhood-list .neighbourhood-name {
-    font-weight: bold;
-    font-size: 1.2em;
   }
 </style>

--- a/web/src/title/LoadSavedProject.svelte
+++ b/web/src/title/LoadSavedProject.svelte
@@ -35,6 +35,6 @@
 </script>
 
 <label>
-  Load a project from a file
+  <strong>Load a project from a file</strong>
   <input bind:this={fileInput} on:change={loadFile} type="file" />
 </label>

--- a/web/src/title/LoadSavedProject.svelte
+++ b/web/src/title/LoadSavedProject.svelte
@@ -34,7 +34,7 @@
   }
 </script>
 
-<label>
+<label style="margin-top: 16px;">
   <strong>Load a project from a file</strong>
   <input bind:this={fileInput} on:change={loadFile} type="file" />
 </label>

--- a/web/src/title/TitleMode.svelte
+++ b/web/src/title/TitleMode.svelte
@@ -78,43 +78,45 @@
   </div>
   <div slot="sidebar">
     {#if $map && wasmReady}
-      <h2>Your Projects</h2>
-      <div class="project-list">
-        {#each projectList as [study_area_name, projects]}
-          <h3 class="study-area">{study_area_name ?? "custom area"}</h3>
-          <ul class="study-area-project-list">
-            {#each projects as { projectId, projectName }}
-              <li>
-                <span
-                  style="display: flex; gap: 16px; justify-content: space-between;"
-                >
-                  <Link on:click={() => loadProject(projectId)}>
-                    {projectName}
-                  </Link>
-                  <span style="display: flex; gap: 16px;">
-                    <button
-                      class="outline icon-btn"
-                      aria-label="Rename project"
-                      on:click={() => renameProject(projectId)}
-                    >
-                      <Pencil color="black" />
-                    </button>
-                    <button
-                      class="icon-btn destructive"
-                      aria-label="Delete project"
-                      on:click={() => deleteProject(projectId)}
-                    >
-                      <Trash2 color="white" />
-                    </button>
+      {#if projectList.length > 0}
+        <h2>Your projects</h2>
+        <div class="project-list">
+          {#each projectList as [study_area_name, projects]}
+            <h3 class="study-area">{study_area_name ?? "custom area"}</h3>
+            <ul class="study-area-project-list">
+              {#each projects as { projectId, projectName }}
+                <li>
+                  <span
+                    style="display: flex; gap: 16px; justify-content: space-between;"
+                  >
+                    <Link on:click={() => loadProject(projectId)}>
+                      {projectName}
+                    </Link>
+                    <span style="display: flex; gap: 16px;">
+                      <button
+                        class="outline icon-btn"
+                        aria-label="Rename project"
+                        on:click={() => renameProject(projectId)}
+                      >
+                        <Pencil color="black" />
+                      </button>
+                      <button
+                        class="icon-btn destructive"
+                        aria-label="Delete project"
+                        on:click={() => deleteProject(projectId)}
+                      >
+                        <Trash2 color="white" />
+                      </button>
+                    </span>
                   </span>
-                </span>
-              </li>
-            {/each}
-          </ul>
-        {/each}
-      </div>
+                </li>
+              {/each}
+            </ul>
+          {/each}
+        </div>
+      {/if}
 
-      <h2>Add a new project</h2>
+      <h2>Start a new project</h2>
       {#if $appFocus == "global"}
         <button on:click={() => ($mode = { mode: "new-project" })}>
           New project
@@ -142,14 +144,20 @@
   }
 
   .study-area-project-list {
-    list-style-type: none;
     padding: 0 8px 0 4px;
     margin: 0;
     margin-bottom: 16px;
   }
 
   .study-area-project-list li {
-    padding: 4px;
+    list-style-type: none;
+    margin-left: 1em;
+    margin: 0;
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+
+  .study-area-project-list li:not(:last-child) {
     border-bottom: 1px solid #ddd;
   }
 </style>

--- a/web/src/title/TitleMode.svelte
+++ b/web/src/title/TitleMode.svelte
@@ -151,8 +151,8 @@
 
   .study-area-project-list li {
     list-style-type: none;
-    margin-left: 1em;
     margin: 0;
+    margin-left: 1em;
     padding-top: 4px;
     padding-bottom: 4px;
   }

--- a/web/src/title/TitleMode.svelte
+++ b/web/src/title/TitleMode.svelte
@@ -82,32 +82,30 @@
         <h2>Your projects</h2>
         <div class="project-list">
           {#each projectList as [study_area_name, projects]}
-            <h3 class="study-area">{study_area_name ?? "custom area"}</h3>
-            <ul class="study-area-project-list">
+            <h3 class="study-area-name">{study_area_name ?? "custom area"}</h3>
+            <ul class="navigable-list">
               {#each projects as { projectId, projectName }}
-                <li>
-                  <span
-                    style="display: flex; gap: 16px; justify-content: space-between;"
-                  >
+                <li class="actionable-cell">
+                  <h3>
                     <Link on:click={() => loadProject(projectId)}>
                       {projectName}
                     </Link>
-                    <span style="display: flex; gap: 16px;">
-                      <button
-                        class="outline icon-btn"
-                        aria-label="Rename project"
-                        on:click={() => renameProject(projectId)}
-                      >
-                        <Pencil color="black" />
-                      </button>
-                      <button
-                        class="icon-btn destructive"
-                        aria-label="Delete project"
-                        on:click={() => deleteProject(projectId)}
-                      >
-                        <Trash2 color="white" />
-                      </button>
-                    </span>
+                  </h3>
+                  <span class="actions">
+                    <button
+                      class="outline icon-btn"
+                      aria-label="Rename project"
+                      on:click={() => renameProject(projectId)}
+                    >
+                      <Pencil color="black" />
+                    </button>
+                    <button
+                      class="icon-btn destructive"
+                      aria-label="Delete project"
+                      on:click={() => deleteProject(projectId)}
+                    >
+                      <Trash2 color="white" />
+                    </button>
                   </span>
                 </li>
               {/each}
@@ -132,32 +130,13 @@
 </SplitComponent>
 
 <style>
-  h2 {
-    font-size: 32px;
-  }
-
-  .project-list h3.study-area {
-    font-size: 20px;
-    padding: 4px;
-    margin: 4px 0;
+  .study-area-name {
     border-bottom: 1px solid #444;
   }
-
-  .study-area-project-list {
-    padding: 0 8px 0 4px;
-    margin: 0;
-    margin-bottom: 16px;
+  .project-list {
+    margin-top: 18px;
   }
-
-  .study-area-project-list li {
-    list-style-type: none;
-    margin: 0;
-    margin-left: 1em;
-    padding-top: 4px;
-    padding-bottom: 4px;
-  }
-
-  .study-area-project-list li:not(:last-child) {
-    border-bottom: 1px solid #ddd;
+  .project-list li {
+    padding-left: 1em;
   }
 </style>

--- a/web/src/title/TitleMode.svelte
+++ b/web/src/title/TitleMode.svelte
@@ -6,7 +6,7 @@
   import { Link } from "../common";
   import { routeTool } from "../common/draw_area/stores";
   import { appFocus, backend, currentProjectKey, map, mode } from "../stores";
-  import { loadFromLocalStorage } from "./loader";
+  import { getProjectList, loadFromLocalStorage } from "./loader";
   import LoadSavedProject from "./LoadSavedProject.svelte";
 
   export let wasmReady: boolean;
@@ -35,46 +35,12 @@
     }
   }
 
-  let projectList = getProjectList();
-
-  // Returns a list, grouped and sorted by the optional study_area_name, with
-  // custom cases at the end
-  function getProjectList(): Array<[string, string[]]> {
-    let perArea = new Map();
-    let custom = [];
-    for (let i = 0; i < window.localStorage.length; i++) {
-      let key = window.localStorage.key(i)!;
-      if (key.startsWith("ltn_")) {
-        let study_area_name = "";
-        try {
-          let gj = JSON.parse(window.localStorage.getItem(key)!);
-          study_area_name = gj.study_area_name;
-        } catch (err) {
-          // Ignore it
-        }
-        if (study_area_name && study_area_name.length > 0) {
-          if (!perArea.has(study_area_name)) {
-            perArea.set(study_area_name, []);
-          }
-          perArea.get(study_area_name)!.push(key);
-        } else {
-          custom.push(key);
-        }
-      }
-    }
-
-    let out = [...perArea.entries()];
-    out.sort((a, b) => a[0].localeCompare(b[0]));
-    if (custom.length > 0) {
-      out.push(["", custom]);
-    }
-    return out;
-  }
+  let projectList = getProjectList($appFocus);
 
   function deleteProject(key: string) {
     if (window.confirm(`Really delete project ${key}? You can't undo this.`)) {
       window.localStorage.removeItem(key);
-      projectList = getProjectList();
+      projectList = getProjectList($appFocus);
     }
   }
 
@@ -89,7 +55,7 @@
       let gj = window.localStorage.getItem(key)!;
       window.localStorage.setItem(newName, gj);
       window.localStorage.removeItem(key);
-      projectList = getProjectList();
+      projectList = getProjectList($appFocus);
     }
   }
 
@@ -112,41 +78,41 @@
   </div>
   <div slot="sidebar">
     {#if $map && wasmReady}
-        <h2>Your Projects</h2>
-        <div class="project-list">
-          {#each projectList as [study_area_name, projects]}
-            <h3 class="study-area">{study_area_name ?? "custom area"}</h3>
-            <ul class="study-area-project-list">
-              {#each projects as project}
-                <li>
-                  <span
-                    style="display: flex; gap: 16px; justify-content: space-between;"
-                  >
-                    <Link on:click={() => loadProject(project)}>
-                      {project.slice("ltn_".length)}
-                    </Link>
-                    <span style="display: flex; gap: 16px;">
-                      <button
-                        class="outline icon-btn"
-                        aria-label="Rename project"
-                        on:click={() => renameProject(project)}
-                      >
-                        <Pencil color="black" />
-                      </button>
-                      <button
-                        class="icon-btn destructive"
-                        aria-label="Delete project"
-                        on:click={() => deleteProject(project)}
-                      >
-                        <Trash2 color="white" />
-                      </button>
-                    </span>
+      <h2>Your Projects</h2>
+      <div class="project-list">
+        {#each projectList as [study_area_name, projects]}
+          <h3 class="study-area">{study_area_name ?? "custom area"}</h3>
+          <ul class="study-area-project-list">
+            {#each projects as { projectId, projectName }}
+              <li>
+                <span
+                  style="display: flex; gap: 16px; justify-content: space-between;"
+                >
+                  <Link on:click={() => loadProject(projectId)}>
+                    {projectName}
+                  </Link>
+                  <span style="display: flex; gap: 16px;">
+                    <button
+                      class="outline icon-btn"
+                      aria-label="Rename project"
+                      on:click={() => renameProject(projectId)}
+                    >
+                      <Pencil color="black" />
+                    </button>
+                    <button
+                      class="icon-btn destructive"
+                      aria-label="Delete project"
+                      on:click={() => deleteProject(projectId)}
+                    >
+                      <Trash2 color="white" />
+                    </button>
                   </span>
-                </li>
-              {/each}
-            </ul>
-          {/each}
-        </div>
+                </span>
+              </li>
+            {/each}
+          </ul>
+        {/each}
+      </div>
 
       <h2>Add a new project</h2>
       {#if $appFocus == "global"}
@@ -154,7 +120,7 @@
           New project
         </button>
       {:else if $appFocus == "cnt"}
-        <CntChooseArea {loadProject} bind:activityIndicatorText={loading} />
+        <CntChooseArea bind:activityIndicatorText={loading} />
       {/if}
       <LoadSavedProject bind:loading />
     {:else}

--- a/web/src/title/TitleMode.svelte
+++ b/web/src/title/TitleMode.svelte
@@ -65,7 +65,9 @@
 
     let out = [...perArea.entries()];
     out.sort((a, b) => a[0].localeCompare(b[0]));
-    out.push(["custom", custom]);
+    if (custom.length > 0) {
+      out.push(["", custom]);
+    }
     return out;
   }
 

--- a/web/src/title/TitleMode.svelte
+++ b/web/src/title/TitleMode.svelte
@@ -112,49 +112,51 @@
   </div>
   <div slot="sidebar">
     {#if $map && wasmReady}
-      {#if $appFocus == "global"}
-        <div>
-          <Link on:click={() => ($mode = { mode: "new-project" })}>
-            New project
-          </Link>
+        <h2>Your Projects</h2>
+        <div class="project-list">
+          {#each projectList as [study_area_name, projects]}
+            <h3 class="study-area">{study_area_name ?? "custom area"}</h3>
+            <ul class="study-area-project-list">
+              {#each projects as project}
+                <li>
+                  <span
+                    style="display: flex; gap: 16px; justify-content: space-between;"
+                  >
+                    <Link on:click={() => loadProject(project)}>
+                      {project.slice("ltn_".length)}
+                    </Link>
+                    <span style="display: flex; gap: 16px;">
+                      <button
+                        class="outline icon-btn"
+                        aria-label="Rename project"
+                        on:click={() => renameProject(project)}
+                      >
+                        <Pencil color="black" />
+                      </button>
+                      <button
+                        class="icon-btn destructive"
+                        aria-label="Delete project"
+                        on:click={() => deleteProject(project)}
+                      >
+                        <Trash2 color="white" />
+                      </button>
+                    </span>
+                  </span>
+                </li>
+              {/each}
+            </ul>
+          {/each}
         </div>
 
-        <p>Load a saved project:</p>
-        <ul>
-          {#each projectList as [study_area_name, projects]}
-            <u>{study_area_name ?? "custom area"}</u>
-            {#each projects as project}
-              <li>
-                <span style="display: flex; justify-content: space-between;">
-                  <Link on:click={() => loadProject(project)}>
-                    {project.slice("ltn_".length)}
-                  </Link>
-                  <span style="display: flex; gap: 16px;">
-                    <button
-                      class="outline icon-btn"
-                      aria-label="Rename project"
-                      on:click={() => renameProject(project)}
-                    >
-                      <Pencil color="black" />
-                    </button>
-                    <button
-                      class="icon-btn destructive"
-                      aria-label="Delete project"
-                      on:click={() => deleteProject(project)}
-                    >
-                      <Trash2 color="white" />
-                    </button>
-                  </span>
-                </span>
-              </li>
-            {/each}
-          {/each}
-        </ul>
-
-        <LoadSavedProject bind:loading />
+      <h2>Add a new project</h2>
+      {#if $appFocus == "global"}
+        <button on:click={() => ($mode = { mode: "new-project" })}>
+          New project
+        </button>
       {:else if $appFocus == "cnt"}
         <CntChooseArea {loadProject} bind:activityIndicatorText={loading} />
       {/if}
+      <LoadSavedProject bind:loading />
     {:else}
       <p>Waiting for MapLibre and WASM to load...</p>
     {/if}
@@ -162,12 +164,26 @@
 </SplitComponent>
 
 <style>
-  /* app specificity to override existing rule for .left  */
-  :global(#app .app-focus-cnt .left) {
-    width: 35%;
+  h2 {
+    font-size: 32px;
   }
-  /* app specificity to override existing rule for .left  */
-  :global(#app .app-focus-cnt .main) {
-    width: 65%;
+
+  .project-list h3.study-area {
+    font-size: 20px;
+    padding: 4px;
+    margin: 4px 0;
+    border-bottom: 1px solid #444;
+  }
+
+  .study-area-project-list {
+    list-style-type: none;
+    padding: 0 8px 0 4px;
+    margin: 0;
+    margin-bottom: 16px;
+  }
+
+  .study-area-project-list li {
+    padding: 4px;
+    border-bottom: 1px solid #ddd;
   }
 </style>

--- a/web/src/title/loader.ts
+++ b/web/src/title/loader.ts
@@ -155,7 +155,6 @@ export function getProjectList(
         continue;
       }
       try {
-        console.log("key", key);
         let [_, studyAreaId, projectName] = key.split("/");
         let studyAreaName = studyAreaId.split("LAD_")[1];
         if (!studyAreas.has(studyAreaName)) {

--- a/web/src/title/loader.ts
+++ b/web/src/title/loader.ts
@@ -151,6 +151,9 @@ export function getProjectList(
   for (let i = 0; i < window.localStorage.length; i++) {
     let key = window.localStorage.key(i)!;
     if (key.startsWith("ltn_cnt/")) {
+      if (appFocus != "cnt") {
+        continue;
+      }
       try {
         console.log("key", key);
         let [_, studyAreaId, projectName] = key.split("/");


### PR DESCRIPTION
FIXES #148 (and beyond!)

## Global

**before:**

<img width="1580" alt="Screenshot 2025-03-12 at 12 51 28" src="https://github.com/user-attachments/assets/c363739a-c83e-448f-8411-2f7c77aeaf4d" />

**after:**

I've lifted the styles from the neighbourhood picker list (and tweaked them a bit) and am now using them for the project picker list.

Returning users most likely care more about their existing projects, so I've moved those *before* the "create" flow. For new users (screenshots farther down) the won't have any existing projects, so the "create" flow will be at the top.

Note: I'm no longer displaying CNT projects on the main LTN page. The more I think about it, the more I think we should try to maintain that these are two different apps with two different databases. Other than us developers, I don't imagine there will be much cross over between the two. But if this is controversial, it's easy to revert this part https://github.com/a-b-street/ltn/pull/224/commits/50e6a14438553ded84e216a917d409b14fdc06a4

<img width="1580" alt="Screenshot 2025-03-12 at 16 34 58" src="https://github.com/user-attachments/assets/bdcaa9c8-f5b2-41bd-a49f-f46714e0b856" />

## cnt

**before:**

<img width="1624" alt="Screenshot 2025-03-12 at 12 51 57" src="https://github.com/user-attachments/assets/a8c152c4-8837-4fed-bc37-74775cfe5064" />

**after:**

Same idea - project list is before "new projects". It's more drastic here since the "create flow" is so much bigger.

I also stripped "LAD" from the study area name, so it matches with the name from the "create" flow.

<img width="1580" alt="Screenshot 2025-03-12 at 16 34 41" src="https://github.com/user-attachments/assets/7b5e449f-9592-4ad5-be76-a4c22c759a75" />


## Empty state before (global)

**before:** inexplicable "load a saved file."

<img width="1624" alt="Screenshot 2025-03-12 at 12 38 38" src="https://github.com/user-attachments/assets/a1a05989-8f1a-4bc3-ad20-b01a5e70f59a" />

**after:** New project is a button

<img width="1624" alt="Screenshot 2025-03-12 at 12 58 54" src="https://github.com/user-attachments/assets/cdfce197-5860-4fc5-8629-fa7d116f3589" />


## Empty state before (CNT)

**before:** inexplicable "Or continue with a previously opened file."

<img width="1264" alt="Screenshot 2025-03-12 at 12 39 16" src="https://github.com/user-attachments/assets/c8f4ea0a-2f2b-4907-8af7-6a380ac14956" />

**after:**

<img width="1624" alt="Screenshot 2025-03-12 at 12 20 27" src="https://github.com/user-attachments/assets/b4bedc27-f777-4239-a349-54b02e175133" />
