### PR TITLE
gray color should only be used for "main" roads

### DIFF
--- a/web/src/common/colors.ts
+++ b/web/src/common/colors.ts
@@ -50,6 +50,9 @@ export function bucketize(limits: number[]) {
   return buckets;
 }
 
+// Like the background of the bike/walk sign
+export const signGreen = "#0C793A";
+
 export const Style = {
   mapFeature: {
     hover: {

--- a/web/src/layers/NeighbourhoodRoadLayer.svelte
+++ b/web/src/layers/NeighbourhoodRoadLayer.svelte
@@ -6,7 +6,12 @@
   import { hoverStateFilter, LineLayer } from "svelte-maplibre";
   import { makeRamp } from "svelte-utils/map";
   import { layerId, roadLineWidth } from "../common";
-  import { speedColorScale, speedLimits, Style } from "../common/colors";
+  import {
+    signGreen,
+    speedColorScale,
+    speedLimits,
+    Style,
+  } from "../common/colors";
   import { roadStyle, thickRoadsForShortcuts } from "../stores";
   import type { RenderNeighbourhoodOutput } from "../wasm";
 
@@ -24,7 +29,7 @@
       return ["get", "color"];
     }
     if (style == "edits") {
-      return ["case", ["get", "edited"], "grey", "white"];
+      return ["case", ["get", "edited"], signGreen, "white"];
     }
     if (style == "speeds") {
       return makeRamp(


### PR DESCRIPTION
Now that we're coloring primary roads gray, let's avoid coloring other roads gray, so as not to confuse.

**before:**
<img width="1580" alt="Screenshot 2025-03-12 at 14 24 27" src="https://github.com/user-attachments/assets/34de4db7-7a1d-4cef-8cac-7178e3e33f0d" />

**after:**
<img width="1580" alt="Screenshot 2025-03-12 at 14 24 07" src="https://github.com/user-attachments/assets/ed1d805e-f813-479f-843d-7e56fef6a70d" />
