### PR TITLE
Impact and route mode improvements

### DIFF
--- a/web/src/PredictImpactMode.svelte
+++ b/web/src/PredictImpactMode.svelte
@@ -6,7 +6,7 @@
   import BackButton from "./BackButton.svelte";
   import { layerId, Link, SequentialLegend } from "./common";
   import { ModalFilterLayer } from "./layers";
-  import { backend, mode, returnToChooseProject } from "./stores";
+  import { backend, mode, onlyNewIcons, returnToChooseProject } from "./stores";
 
   // Based partly on https://colorbrewer2.org/#type=diverging&scheme=RdYlGn&n=5
   // The middle color white doesn't matter; the source data will filter out unchanged roads
@@ -62,6 +62,11 @@
       colorScale={divergingScale}
       labels={{ limits: ["0%", "50%", "same", "150%", "200%"] }}
     />
+
+    <label>
+      <input type="checkbox" bind:checked={$onlyNewIcons} />
+      Only show new modal filters and turn restrictions
+    </label>
   </div>
 
   <div slot="map">
@@ -140,6 +145,6 @@
       </LineLayer>
     </GeoJSON>
 
-    <ModalFilterLayer />
+    <ModalFilterLayer onlyNew={$onlyNewIcons} />
   </div>
 </SplitComponent>

--- a/web/src/PredictImpactMode.svelte
+++ b/web/src/PredictImpactMode.svelte
@@ -6,7 +6,7 @@
   import BackButton from "./BackButton.svelte";
   import { layerId, Link, SequentialLegend } from "./common";
   import { ModalFilterLayer } from "./layers";
-  import { backend, mode, onlyNewIcons, returnToChooseProject } from "./stores";
+  import { backend, mode, returnToChooseProject } from "./stores";
 
   // Based partly on https://colorbrewer2.org/#type=diverging&scheme=RdYlGn&n=5
   // The middle color white doesn't matter; the source data will filter out unchanged roads
@@ -62,11 +62,6 @@
       colorScale={divergingScale}
       labels={{ limits: ["0%", "50%", "same", "150%", "200%"] }}
     />
-
-    <label>
-      <input type="checkbox" bind:checked={$onlyNewIcons} />
-      Only show new modal filters and turn restrictions
-    </label>
   </div>
 
   <div slot="map">
@@ -145,6 +140,6 @@
       </LineLayer>
     </GeoJSON>
 
-    <ModalFilterLayer onlyNew={$onlyNewIcons} />
+    <ModalFilterLayer />
   </div>
 </SplitComponent>

--- a/web/src/RouteMode.svelte
+++ b/web/src/RouteMode.svelte
@@ -35,6 +35,8 @@
     | "impact-one-destination";
 
   $: gj = $backend!.compareRoute($routePtA, $routePtB, $mainRoadPenalty);
+  $: routeBefore = gj.features.find((f) => f.properties.kind == "before");
+  $: routeAfter = gj.features.find((f) => f.properties.kind == "after");
 
   onMount(() => {
     // There seems to be a race with the Marker component, so we wait just a bit before updating.
@@ -76,19 +78,27 @@
     <BackButton on:click={back} />
 
     <p>Drag markers for a route</p>
-    {#if gj.features.length == 2}
+
+    <u style:color="red">Route before changes</u>
+    {#if routeBefore}
       <p>
-        <span style="color: red">Route before</span>
-        : {prettyPrintDistance(gj.features[0].properties.distance)}, {prettyPrintTime(
-          gj.features[0].properties.time,
+        {prettyPrintDistance(routeBefore.properties.distance)}, {prettyPrintTime(
+          routeBefore.properties.time,
         )}
       </p>
+    {:else}
+      <p>No possible route (<i>This is usually a known software bug</i>)</p>
+    {/if}
+
+    <u style:color="blue">Route after changes</u>
+    {#if routeAfter}
       <p>
-        <span style="color: blue">Route after</span>
-        : {prettyPrintDistance(gj.features[1].properties.distance)}, {prettyPrintTime(
-          gj.features[1].properties.time,
+        {prettyPrintDistance(routeAfter.properties.distance)}, {prettyPrintTime(
+          routeAfter.properties.time,
         )}
       </p>
+    {:else}
+      <p>No possible route (<i>This is usually a known software bug</i>)</p>
     {/if}
 
     <label>

--- a/web/src/RouteMode.svelte
+++ b/web/src/RouteMode.svelte
@@ -87,7 +87,11 @@
         )}
       </p>
     {:else}
-      <p>No possible route (<i>This is usually a known software bug</i>)</p>
+      <p>
+        No possible route (
+        <i>This is usually a known software bug</i>
+        )
+      </p>
     {/if}
 
     <u style:color="blue">Route after changes</u>
@@ -98,7 +102,11 @@
         )}
       </p>
     {:else}
-      <p>No possible route (<i>This is usually a known software bug</i>)</p>
+      <p>
+        No possible route (
+        <i>This is usually a known software bug</i>
+        )
+      </p>
     {/if}
 
     <label>

--- a/web/src/common/DotMarker.svelte
+++ b/web/src/common/DotMarker.svelte
@@ -25,7 +25,7 @@
     justify-content: center;
     align-items: center;
 
-    background-color: grey;
+    background-color: orange;
     font-weight: bold;
   }
 </style>

--- a/web/src/context/ContextualLayers.svelte
+++ b/web/src/context/ContextualLayers.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { Layers } from "lucide-svelte";
   import { Control } from "svelte-maplibre";
+  import { ContextLayerButton } from "../common";
+  import { showExistingFiltersAndTRs } from "../stores";
   import BusRoutes from "./BusRoutes.svelte";
   import CBD from "./CBD.svelte";
   import POIs from "./POIs.svelte";
@@ -38,6 +40,11 @@
       style:display={expand ? "flex" : "none"}
       style:background-color="#515f7A"
     >
+      <ContextLayerButton
+        label="Existing modal filters and turn restrictions"
+        bind:show={$showExistingFiltersAndTRs}
+      />
+
       <POIs />
       <Population />
       <RailwayStations />

--- a/web/src/layers/ModalFilterLayer.svelte
+++ b/web/src/layers/ModalFilterLayer.svelte
@@ -2,12 +2,15 @@
   import { GeoJSON, SymbolLayer, type LayerClickInfo } from "svelte-maplibre";
   import { emptyGeojson } from "svelte-utils/map";
   import { layerId } from "../common";
-  import { backend, mutationCounter } from "../stores";
+  import {
+    backend,
+    mutationCounter,
+    showExistingFiltersAndTRs,
+  } from "../stores";
   // TODO Maybe make another component wrapping both modal filters and turn
   // restrictions, since all callers want both
   import TurnRestrictionLayer from "./TurnRestrictionLayer.svelte";
 
-  export let onlyNew = false;
   export let onClickModalFilter: (
     e: CustomEvent<LayerClickInfo>,
   ) => void = () => {};
@@ -27,7 +30,7 @@
     filter={[
       "all",
       ["!=", ["get", "filter_kind"], "diagonal_filter"],
-      onlyNew ? ["get", "edited"] : ["literal", true],
+      $showExistingFiltersAndTRs ? ["literal", true] : ["get", "edited"],
     ]}
     {minzoom}
     layout={{
@@ -57,6 +60,6 @@
   />
 </GeoJSON>
 
-<TurnRestrictionLayer {onlyNew} {onClickTurnRestriction}>
+<TurnRestrictionLayer {onClickTurnRestriction}>
   <slot name="turn-restriction" />
 </TurnRestrictionLayer>

--- a/web/src/layers/ModalFilterLayer.svelte
+++ b/web/src/layers/ModalFilterLayer.svelte
@@ -7,6 +7,7 @@
   // restrictions, since all callers want both
   import TurnRestrictionLayer from "./TurnRestrictionLayer.svelte";
 
+  export let onlyNew = false;
   export let onClickModalFilter: (
     e: CustomEvent<LayerClickInfo>,
   ) => void = () => {};
@@ -23,7 +24,11 @@
 <GeoJSON data={gj} generateId>
   <SymbolLayer
     {...layerId("modal-filters")}
-    filter={["!=", ["get", "filter_kind"], "diagonal_filter"]}
+    filter={[
+      "all",
+      ["!=", ["get", "filter_kind"], "diagonal_filter"],
+      onlyNew ? ["get", "edited"] : ["literal", true],
+    ]}
     {minzoom}
     layout={{
       "icon-image": ["get", "filter_kind"],
@@ -52,6 +57,6 @@
   />
 </GeoJSON>
 
-<TurnRestrictionLayer {onClickTurnRestriction}>
+<TurnRestrictionLayer {onlyNew} {onClickTurnRestriction}>
   <slot name="turn-restriction" />
 </TurnRestrictionLayer>

--- a/web/src/layers/TurnRestrictionLayer.svelte
+++ b/web/src/layers/TurnRestrictionLayer.svelte
@@ -10,6 +10,7 @@
   import { layerId } from "../common";
   import { backend, mutationCounter } from "../stores";
 
+  export let onlyNew: boolean;
   export let onClickTurnRestriction: (
     e: CustomEvent<LayerClickInfo>,
   ) => void = () => {};
@@ -47,6 +48,7 @@
   <SymbolLayer
     {...layerId("turn-restrictions")}
     minzoom={13}
+    filter={onlyNew ? ["get", "edited"] : undefined}
     layout={{
       "icon-image": ["concat", "no_", ["get", "kind"], "_turn"],
       "icon-rotate": ["get", "icon_angle"],

--- a/web/src/layers/TurnRestrictionLayer.svelte
+++ b/web/src/layers/TurnRestrictionLayer.svelte
@@ -8,9 +8,12 @@
   } from "svelte-maplibre";
   import { emptyGeojson } from "svelte-utils/map";
   import { layerId } from "../common";
-  import { backend, mutationCounter } from "../stores";
+  import {
+    backend,
+    mutationCounter,
+    showExistingFiltersAndTRs,
+  } from "../stores";
 
-  export let onlyNew: boolean;
   export let onClickTurnRestriction: (
     e: CustomEvent<LayerClickInfo>,
   ) => void = () => {};
@@ -48,7 +51,7 @@
   <SymbolLayer
     {...layerId("turn-restrictions")}
     minzoom={13}
-    filter={onlyNew ? ["get", "edited"] : undefined}
+    filter={$showExistingFiltersAndTRs ? undefined : ["get", "edited"]}
     layout={{
       "icon-image": ["concat", "no_", ["get", "kind"], "_turn"],
       "icon-rotate": ["get", "icon_angle"],

--- a/web/src/stores.ts
+++ b/web/src/stores.ts
@@ -88,7 +88,7 @@ export let devMode: Writable<boolean> = writable(false);
 export let maptilerBasemap: Writable<string> = writable("streets-v2");
 export let filterType: Writable<string> = writable("walk_cycle_only");
 export let animateShortcuts = writable(false);
-export let onlyNewIcons = writable(false);
+export let showExistingFiltersAndTRs = writable(true);
 export let roadStyle: Writable<"shortcuts" | "cells" | "edits" | "speeds"> =
   writable("shortcuts");
 export let thickRoadsForShortcuts = writable(false);

--- a/web/src/stores.ts
+++ b/web/src/stores.ts
@@ -88,6 +88,7 @@ export let devMode: Writable<boolean> = writable(false);
 export let maptilerBasemap: Writable<string> = writable("streets-v2");
 export let filterType: Writable<string> = writable("walk_cycle_only");
 export let animateShortcuts = writable(false);
+export let onlyNewIcons = writable(false);
 export let roadStyle: Writable<"shortcuts" | "cells" | "edits" | "speeds"> =
   writable("shortcuts");
 export let thickRoadsForShortcuts = writable(false);

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -234,10 +234,7 @@ export class Backend {
     pt1: LngLat,
     pt2: LngLat,
     mainRoadPenalty: number,
-  ): FeatureCollection<
-    LineString,
-    { kind: "before" | "after"; distance: number; time: number }
-  > {
+  ): CompareRoute {
     return JSON.parse(
       this.inner.compareRoute(
         pt1.lng,
@@ -386,6 +383,11 @@ export interface RenderNeighbourhoodOutput {
 export type AllShortcuts = FeatureCollection<
   LineString,
   { directness: number; length_meters: number }
+>;
+
+export type CompareRoute = FeatureCollection<
+  LineString,
+  { kind: "before" | "after"; distance: number; time: number }
 >;
 
 // Sets a 'color' property on any cell polygons. Idempotent.

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -271,8 +271,8 @@ export class Backend {
     road: number,
   ): Array<
     [
-      Feature<LineString, { kind: "before" }>,
-      Feature<LineString, { kind: "after" }>,
+      Feature<LineString, { kind: "before" }> | null,
+      Feature<LineString, { kind: "after" }> | null,
     ]
   > {
     return JSON.parse(this.inner.getImpactsOnRoad(road));


### PR DESCRIPTION
A few related changes.

## Route mode

#181 found a case where a route exists before edits, but not after. Previously we just showed the red "before" route, which was very confusing. Now it's hopefully more clear:

[Screencast from 16-03-25 14:07:11.webm](https://github.com/user-attachments/assets/ddc8e9b7-67d2-4d94-b274-9f737d6364d0)

Also, made the A/B dot markers orange instead of grey, since grey is pretty hard to spot and also means "main road" now.

## Impact to one destination mode

Previously, when you hover on a road, you got a wall of text, and the blue/red routes were unlabeled mysteries. Now it's hopefully more clear:
![image](https://github.com/user-attachments/assets/4767b27d-194f-4531-bccb-3914cc8d15f5)
Think that time ratio should also move to the sidebar and out of the popup? Or are there other things in this mode that don't feel easy to understand?

## Predict impact mode

Part of #36. Previously, you would click some roads with changed counts and get an error message. Now, it's a bit more clear:

![image](https://github.com/user-attachments/assets/3ee36b19-babd-45f1-b58e-1c4485d33bb1)

Zooming in, the bug is clear -- when the start or end road has a filter, we give up immediately. But we should try routing the other direction away from the filter.
![image](https://github.com/user-attachments/assets/c3bd9d78-6816-4a0b-b702-bca4e3be7f57)

And the other change is to optionally hide unedited filters and TRs. Without this, it's pretty hard to intuit about the red and green roads:
![image](https://github.com/user-attachments/assets/fe8b982f-a64b-4885-b494-0e798032b377)
Better after:
![image](https://github.com/user-attachments/assets/406836ef-b88d-44cc-9046-67aee6eed9d5)

Should this setting be available outside of this mode? Only danger is that when editing, the user might forget this setting is enabled and get very confused looking at cells, shortcuts, etc.