### PR TITLE
FIX: Layers checkbox getting smooshed sometimes.

### DIFF
--- a/web/src/common/ContextLayerButton.svelte
+++ b/web/src/common/ContextLayerButton.svelte
@@ -10,7 +10,7 @@
   class="secondary"
   on:click={() => (show = !show)}
 >
-  <input type="checkbox" bind:checked={show} />
+  <input style="aspect-ratio: 1.0" type="checkbox" bind:checked={show} />
   {label}
   {#if $$slots.help}
     <HelpButton color="var(--pico-secondary-inverse)">


### PR DESCRIPTION
The "existing modal filters and turn restrictions" label is long, and was causing its checkbox to be smooshed.

**before:**

<img width="318" alt="Screenshot 2025-03-20 at 06 32 27" src="https://github.com/user-attachments/assets/e4820295-9d3a-4859-90ae-643c48e6e257" />


**after:**

<img width="175" alt="Screenshot 2025-03-20 at 06 33 04" src="https://github.com/user-attachments/assets/8df395da-e00b-4ef5-8699-d03dd7337a42" />
