### PR TITLE
More features for impact prediction

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -52,6 +52,10 @@ name = "build_neighbourhood"
 harness = false
 
 [[bench]]
+name = "impact"
+harness = false
+
+[[bench]]
 name = "router"
 harness = false
 

--- a/backend/benches/impact.rs
+++ b/backend/benches/impact.rs
@@ -1,0 +1,29 @@
+use backend::test_fixtures::NeighbourhoodFixture;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn benchmark_impact(c: &mut Criterion) {
+    for fixture in [NeighbourhoodFixture::DUNDEE] {
+        let mut map = fixture.map_model().unwrap();
+        let fast_sample = false;
+
+        // Do the first calculation (making the requests and counts_before) outside of the benchmark
+        map.rebuild_router(1.0);
+        {
+            let mut impact = map.impact.take().unwrap();
+            impact.recalculate(&map, fast_sample);
+            map.impact = Some(impact);
+        }
+
+        c.bench_function("predict impact", |b| {
+            b.iter(|| {
+                let mut impact = map.impact.take().unwrap();
+                impact.invalidate_after_edits();
+                impact.recalculate(&map, fast_sample);
+                map.impact = Some(impact);
+            })
+        });
+    }
+}
+
+criterion_group!(benches, benchmark_impact);
+criterion_main!(benches);

--- a/backend/benches/impact.rs
+++ b/backend/benches/impact.rs
@@ -14,14 +14,16 @@ fn benchmark_impact(c: &mut Criterion) {
             map.impact = Some(impact);
         }
 
-        c.bench_function("predict impact", |b| {
-            b.iter(|| {
-                let mut impact = map.impact.take().unwrap();
-                impact.invalidate_after_edits();
-                impact.recalculate(&map, fast_sample);
-                map.impact = Some(impact);
-            })
-        });
+        c.benchmark_group(fixture.savefile_name)
+            .sample_size(10)
+            .bench_function("predict impact", |b| {
+                b.iter(|| {
+                    let mut impact = map.impact.take().unwrap();
+                    impact.invalidate_after_edits();
+                    impact.recalculate(&map, fast_sample);
+                    map.impact = Some(impact);
+                })
+            });
     }
 }
 

--- a/backend/src/create.rs
+++ b/backend/src/create.rs
@@ -251,7 +251,7 @@ pub fn create_from_osm(
 
         travel_flows,
 
-        impact: None,
+        impact: Some(Impact::default()),
         demand: None,
 
         undo_stack: Vec::new(),
@@ -261,10 +261,7 @@ pub fn create_from_osm(
     };
     if let Some(mut demand) = demand {
         demand.finish_loading(&map.mercator);
-        map.impact = Some(Impact::new(&map, Some(&demand)));
         map.demand = Some(demand);
-    } else {
-        map.impact = Some(Impact::new(&map, None));
     }
 
     let graph = GraphSubset {

--- a/backend/src/impact.rs
+++ b/backend/src/impact.rs
@@ -61,7 +61,6 @@ impl Impact {
                 requests.len()
             );
             self.counts_before = map.router_before.od_to_counts(requests);
-            self.last_fast_sample = fast_sample;
         }
 
         if self.counts_after.is_empty() || fast_sample != self.last_fast_sample {
@@ -74,8 +73,8 @@ impl Impact {
                 .as_ref()
                 .expect("need to rebuild_router")
                 .od_to_counts(requests);
-            self.last_fast_sample = fast_sample;
         }
+        self.last_fast_sample = fast_sample;
 
         let mut features = Vec::new();
         let mut max_count = 0;

--- a/backend/src/impact.rs
+++ b/backend/src/impact.rs
@@ -87,13 +87,13 @@ impl Impact {
         &self,
         map: &MapModel,
         road: RoadID,
-    ) -> Vec<(Option<Feature>, Option<Feature>)> {
+    ) -> Vec<(usize, Option<Feature>, Option<Feature>)> {
         let mut changed_paths = Vec::new();
 
         let router_after = map.router_after.as_ref().unwrap();
 
         // TODO We could remember the indices of requests that have changes
-        for (r1, r2, _) in &self.requests {
+        for (r1, r2, count) in &self.requests {
             let route1 = map.router_before.route_from_roads(*r1, *r2);
             let route2 = router_after.route_from_roads(*r1, *r2);
             let crosses1 = route1
@@ -116,7 +116,7 @@ impl Impact {
                     f.set_property("kind", "after");
                     f
                 });
-                changed_paths.push((f1, f2));
+                changed_paths.push((*count, f1, f2));
             }
         }
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -436,27 +436,26 @@ impl LTN {
 
     /// Returns GJ with a LineString per road, with before/after counts
     #[wasm_bindgen(js_name = predictImpact)]
-    pub fn predict_impact(&mut self) -> Result<String, JsValue> {
+    pub fn predict_impact(&mut self, fast_sample: bool) -> Result<String, JsValue> {
         self.map.rebuild_router(1.0);
         let mut impact = self.map.impact.take().unwrap();
-        let out = impact.recalculate(&self.map);
+        let out = impact.recalculate(&self.map, fast_sample);
         self.map.impact = Some(impact);
         Ok(serde_json::to_string(&out).map_err(err_to_js)?)
     }
 
     /// Returns a JSON blob [{before, after}], with before and after being LineStrings
     #[wasm_bindgen(js_name = getImpactsOnRoad)]
-    pub fn get_impacts_on_road(&self, road: usize) -> Result<String, JsValue> {
+    pub fn get_impacts_on_road(&self, road: usize, fast_sample: bool) -> Result<String, JsValue> {
         // Shouldn't need to recalculate impact
-        Ok(serde_json::to_string(
-            &self
-                .map
-                .impact
-                .as_ref()
-                .unwrap()
-                .get_impacts_on_road(&self.map, RoadID(road)),
+        Ok(
+            serde_json::to_string(&self.map.impact.as_ref().unwrap().get_impacts_on_road(
+                &self.map,
+                RoadID(road),
+                fast_sample,
+            ))
+            .map_err(err_to_js)?,
         )
-        .map_err(err_to_js)?)
     }
 
     #[wasm_bindgen(js_name = getAllNeighbourhoods)]

--- a/backend/src/map_model.rs
+++ b/backend/src/map_model.rs
@@ -54,6 +54,7 @@ pub struct MapModel {
     // Every road is filled out
     pub travel_flows: BTreeMap<RoadID, TravelFlow>,
 
+    // Not optional, but wrapped for the borrow checker
     pub impact: Option<Impact>,
     pub demand: Option<DemandModel>,
 

--- a/backend/src/od.rs
+++ b/backend/src/od.rs
@@ -31,22 +31,19 @@ impl DemandModel {
         }
     }
 
-    pub fn make_requests(&self, map: &MapModel) -> Vec<(RoadID, RoadID, usize)> {
+    pub fn make_requests(&self, map: &MapModel, fast_sample: bool) -> Vec<(RoadID, RoadID, usize)> {
         info!(
-            "Making requests from {} zones and {} desire lines",
+            "Making requests from {} zones and {} desire lines, sampling = {fast_sample}",
             self.zones.len(),
             self.desire_lines.len()
         );
-
-        // TODO Plumb through UI
-        // To speed up the impact calculation, how many specific requests per (zone1, zone2)? If
-        // true, just do one, but weight it by count.
-        let fast_sample = true;
 
         let mut rng = WyRand::new_seed(42);
         let mut requests = Vec::new();
 
         for (zone1, zone2, raw_count) in &self.desire_lines {
+            // To speed up the impact calculation, how many specific requests per (zone1, zone2)? If
+            // true, just do one, but weight it by count.
             let (iterations, trip_count) = if fast_sample {
                 (1, *raw_count)
             } else {

--- a/backend/src/test_fixtures.rs
+++ b/backend/src/test_fixtures.rs
@@ -86,9 +86,6 @@ impl NeighbourhoodFixture {
     }
 
     fn context_data(&self) -> Option<ContextData> {
-        if !self.is_cnt {
-            return None;
-        }
         let path = self.context_data_path()?;
         let context_data_bytes =
             std::fs::read(&path).expect(&format!("unable to read context_data: {path}"));

--- a/web/src/AddNeighbourhoodMode.svelte
+++ b/web/src/AddNeighbourhoodMode.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
   import type { Feature, FeatureCollection, Polygon } from "geojson";
   import { Trash2 } from "lucide-svelte";
-  import type {
-    DataDrivenPropertyValueSpecification,
-    ExpressionSpecification,
-  } from "maplibre-gl";
+  import type { DataDrivenPropertyValueSpecification } from "maplibre-gl";
   import { onMount } from "svelte";
   import {
     FillLayer,

--- a/web/src/DebugDemandMode.svelte
+++ b/web/src/DebugDemandMode.svelte
@@ -84,15 +84,17 @@
             Pick neighbourhood
           </Link>
         </li>
-        <li>Debug demand model</li>
+        <li>Explore origin/destination demand data</li>
       </ul>
     </nav>
   </div>
 
   <div slot="sidebar">
-    <BackButton on:click={() => ($mode = { mode: "pick-neighbourhood" })} />
+    <BackButton on:click={() => ($mode = { mode: "predict-impact" })} />
 
-    <p>{gj.features.length.toLocaleString()} zones</p>
+    <!-- TODO Plumb through metadata about the sources used -->
+
+    <p>Trips begin and end in {gj.features.length.toLocaleString()} zones</p>
 
     <label>
       Trips from

--- a/web/src/ImpactDetailMode.svelte
+++ b/web/src/ImpactDetailMode.svelte
@@ -27,22 +27,24 @@
   function gj(idx: number): FeatureCollection {
     return {
       type: "FeatureCollection" as const,
-      features: [routes[idx][0], routes[idx][1], road].filter((f) => f != null),
+      features: [routes[idx].before, routes[idx].after, road].filter(
+        (f) => f != null,
+      ),
     };
   }
 
   function startPos(idx: number): [number, number] {
-    if (routes[idx][0] != null) {
-      return gjPosition(routes[idx][0].geometry.coordinates[0]);
+    if (routes[idx].before != null) {
+      return gjPosition(routes[idx].before.geometry.coordinates[0]);
     }
-    return gjPosition(routes[idx][1]!.geometry.coordinates[0]);
+    return gjPosition(routes[idx].after!.geometry.coordinates[0]);
   }
 
   function endPos(idx: number): [number, number] {
     let pts =
-      routes[idx][0] != null
-        ? routes[idx][0].geometry.coordinates
-        : routes[idx][1]!.geometry.coordinates;
+      routes[idx].before != null
+        ? routes[idx].before.geometry.coordinates
+        : routes[idx].after!.geometry.coordinates;
     return gjPosition(pts[pts.length - 1]);
   }
 </script>
@@ -76,20 +78,27 @@
       {Math.round((100 * props.after) / props.before)}% of the original traffic.
     </p>
 
-    <p>
-      Note: The routes are currently sampled, to speed things up. This one
-      sample route may represent many trips between the same points.
-    </p>
-
     <PrevNext list={routes} bind:idx />
 
-    {#if routes[idx][0] == null}
+    {#if routes[idx].count > 1}
+      <p>
+        The routes are currently sampled, to speed things up. This one sample
+        route represents {routes[idx].count.toLocaleString()} trips between the same
+        points.
+      </p>
+      <i>
+        Note: if these don't sum to the total above, that's likely a known
+        software bug
+      </i>
+    {/if}
+
+    {#if routes[idx].before == null}
       <p style:color="red">
         No possible route before changes (
         <i>This is usually a known software bug</i>
       </p>
     {/if}
-    {#if routes[idx][1] == null}
+    {#if routes[idx].after == null}
       <p style:color="blue">
         No possible route after changes (
         <i>This is usually a known software bug</i>

--- a/web/src/ImpactDetailMode.svelte
+++ b/web/src/ImpactDetailMode.svelte
@@ -6,7 +6,7 @@
   import BackButton from "./BackButton.svelte";
   import { DotMarker, gjPosition, layerId, Link, PrevNext } from "./common";
   import { ModalFilterLayer } from "./layers";
-  import { backend, mode, returnToChooseProject } from "./stores";
+  import { backend, fastSample, mode, returnToChooseProject } from "./stores";
 
   export let road: Feature;
 
@@ -14,7 +14,7 @@
   let props = road.properties!;
   props.kind = "focus";
 
-  let routes = $backend!.getImpactsOnRoad(props.id);
+  let routes = $backend!.getImpactsOnRoad(props.id, $fastSample);
   let idx = 0;
 
   if (routes.length == 0) {
@@ -78,31 +78,33 @@
       {Math.round((100 * props.after) / props.before)}% of the original traffic.
     </p>
 
-    <PrevNext list={routes} bind:idx />
+    {#if routes.length > 0}
+      <PrevNext list={routes} bind:idx />
 
-    {#if routes[idx].count > 1}
-      <p>
-        The routes are currently sampled, to speed things up. This one sample
-        route represents {routes[idx].count.toLocaleString()} trips between the same
-        points.
-      </p>
-      <i>
-        Note: if these don't sum to the total above, that's likely a known
-        software bug
-      </i>
-    {/if}
+      {#if routes[idx].count > 1}
+        <p>
+          The routes are currently sampled, to speed things up. This one sample
+          route represents {routes[idx].count.toLocaleString()} trips between the
+          same points.
+        </p>
+        <i>
+          Note: if these don't sum to the total above, that's likely a known
+          software bug
+        </i>
+      {/if}
 
-    {#if routes[idx].before == null}
-      <p style:color="red">
-        No possible route before changes (
-        <i>This is usually a known software bug</i>
-      </p>
-    {/if}
-    {#if routes[idx].after == null}
-      <p style:color="blue">
-        No possible route after changes (
-        <i>This is usually a known software bug</i>
-      </p>
+      {#if routes[idx].before == null}
+        <p style:color="red">
+          No possible route before changes (
+          <i>This is usually a known software bug</i>
+        </p>
+      {/if}
+      {#if routes[idx].after == null}
+        <p style:color="blue">
+          No possible route after changes (
+          <i>This is usually a known software bug</i>
+        </p>
+      {/if}
     {/if}
   </div>
 

--- a/web/src/PickNeighbourhoodMode.svelte
+++ b/web/src/PickNeighbourhoodMode.svelte
@@ -183,11 +183,6 @@
               Debug intersections
             </Link>
           </li>
-          <li>
-            <Link on:click={() => ($mode = { mode: "debug-demand" })}>
-              Debug demand
-            </Link>
-          </li>
         {/if}
       </ul>
     </nav>

--- a/web/src/PredictImpactMode.svelte
+++ b/web/src/PredictImpactMode.svelte
@@ -48,6 +48,11 @@
     impactGj = $backend!.predictImpact(fastSample);
     loading = "";
   }
+
+  let fastSampleRadio = $fastSample ? "fast" : "accurate";
+  function updateFastSample() {
+    $fastSample = fastSampleRadio == "fast";
+  }
 </script>
 
 <Loading {loading} />
@@ -80,22 +85,35 @@
       </Link>
     </p>
 
-    <label>
-      <input type="checkbox" bind:checked={$fastSample} />
-      Calculate quickly and less accurately
-    </label>
+    <fieldset>
+      <label>
+        <input
+          type="radio"
+          value="fast"
+          bind:group={fastSampleRadio}
+          on:change={updateFastSample}
+        />
+        Calculate quickly
+      </label>
+      <label>
+        <input
+          type="radio"
+          value="accurate"
+          bind:group={fastSampleRadio}
+          on:change={updateFastSample}
+        />
+        Calculate more accurately
+      </label>
+    </fieldset>
 
     <p>
-      Red roads have increased traffic, and green roads have decreased. If
-      hovering on a road doesn't show anything, there was no change there. Click
-      a road to see example routes through it that've changed.
-    </p>
-    <p>
-      Thicker roads have more traffic after edits, relative to the max count for
-      any road: {impactGj.max_count.toLocaleString()}
+      Red roads have increased traffic, and green roads have decreased. Thicker
+      roads have more traffic after edits. If hovering on a road doesn't show
+      anything, there was no change there. Click a road to see example routes
+      through it that've changed.
     </p>
     <label>
-      Only show roads with at least this much traffic before or after
+      Only show roads with at least this many daily trips before or after
       <input type="number" min={0} bind:value={$minImpactCount} />
     </label>
 

--- a/web/src/PredictImpactMode.svelte
+++ b/web/src/PredictImpactMode.svelte
@@ -46,8 +46,11 @@
     <p>
       This mode estimates the impact of all your changes on traffic around the
       entire area. It's based on many assumptions and must be interpreted very
-      carefully.
+      carefully. <Link on:click={() => ($mode = { mode: "debug-demand" })}>
+        Explore the origin/destination demand data used
+      </Link>
     </p>
+
     <p>
       Red roads have increased traffic, and green roads have decreased. If
       hovering on a road doesn't show anything, there was no change there. Click

--- a/web/src/PredictImpactMode.svelte
+++ b/web/src/PredictImpactMode.svelte
@@ -6,13 +6,13 @@
   import BackButton from "./BackButton.svelte";
   import { layerId, Link, SequentialLegend } from "./common";
   import { ModalFilterLayer } from "./layers";
-  import { backend, mode, returnToChooseProject } from "./stores";
+  import { backend, fastSample, mode, returnToChooseProject } from "./stores";
 
   // Based partly on https://colorbrewer2.org/#type=diverging&scheme=RdYlGn&n=5
   // The middle color white doesn't matter; the source data will filter out unchanged roads
   let divergingScale = ["#1a9641", "#a6d96a", "white", "#fdae61", "#d7191c"];
 
-  let impactGj = $backend!.predictImpact();
+  $: impactGj = $backend!.predictImpact($fastSample);
   let neighbourhoods = $backend!.getAllNeighbourhoods();
 
   let minRoadWidth = 3;
@@ -50,6 +50,11 @@
         Explore the origin/destination demand data used
       </Link>
     </p>
+
+    <label>
+      <input type="checkbox" bind:checked={$fastSample} />
+      Calculate quickly and less accurately
+    </label>
 
     <p>
       Red roads have increased traffic, and green roads have decreased. If

--- a/web/src/PredictImpactMode.svelte
+++ b/web/src/PredictImpactMode.svelte
@@ -122,7 +122,7 @@
         {...layerId("predict-impact-outline")}
         filter={[
           ">=",
-          ["min", ["get", "before"], ["get", "after"]],
+          ["max", ["get", "before"], ["get", "after"]],
           $minImpactCount,
         ]}
         paint={{
@@ -143,7 +143,7 @@
         {...layerId("predict-impact")}
         filter={[
           ">=",
-          ["min", ["get", "before"], ["get", "after"]],
+          ["max", ["get", "before"], ["get", "after"]],
           $minImpactCount,
         ]}
         paint={{

--- a/web/src/PredictImpactMode.svelte
+++ b/web/src/PredictImpactMode.svelte
@@ -6,7 +6,13 @@
   import BackButton from "./BackButton.svelte";
   import { layerId, Link, SequentialLegend } from "./common";
   import { ModalFilterLayer } from "./layers";
-  import { backend, fastSample, mode, returnToChooseProject } from "./stores";
+  import {
+    backend,
+    fastSample,
+    minImpactCount,
+    mode,
+    returnToChooseProject,
+  } from "./stores";
 
   // Based partly on https://colorbrewer2.org/#type=diverging&scheme=RdYlGn&n=5
   // The middle color white doesn't matter; the source data will filter out unchanged roads
@@ -65,6 +71,10 @@
       Thicker roads have more traffic after edits, relative to the max count for
       any road: {impactGj.max_count.toLocaleString()}
     </p>
+    <label>
+      Only show roads with at least this much traffic before or after
+      <input type="number" min={0} bind:value={$minImpactCount} />
+    </label>
 
     <SequentialLegend
       colorScale={divergingScale}
@@ -87,6 +97,11 @@
     <GeoJSON data={impactGj} generateId>
       <LineLayer
         {...layerId("predict-impact-outline")}
+        filter={[
+          ">=",
+          ["min", ["get", "before"], ["get", "after"]],
+          $minImpactCount,
+        ]}
         paint={{
           "line-width": [
             "interpolate",
@@ -103,6 +118,11 @@
 
       <LineLayer
         {...layerId("predict-impact")}
+        filter={[
+          ">=",
+          ["min", ["get", "before"], ["get", "after"]],
+          $minImpactCount,
+        ]}
         paint={{
           "line-width": [
             "interpolate",

--- a/web/src/stores.ts
+++ b/web/src/stores.ts
@@ -92,7 +92,6 @@ export let routePtA: Writable<LngLat> = writable(new LngLat(0, 0));
 export let routePtB: Writable<LngLat> = writable(new LngLat(0, 0));
 export let oneDestination: Writable<LngLat> = writable(new LngLat(0, 0));
 export let mainRoadPenalty: Writable<number> = writable(1.0);
-export let fastSample: Writable<boolean> = writable(true);
 // A way for different components to know when internal app state has changed
 // and they might need to rerender
 export let mutationCounter: Writable<number> = writable(1);
@@ -107,6 +106,10 @@ export let showExistingFiltersAndTRs = writable(true);
 export let roadStyle: Writable<"shortcuts" | "cells" | "edits" | "speeds"> =
   writable("shortcuts");
 export let thickRoadsForShortcuts = writable(false);
+
+// Settings for impact prediction
+export let fastSample: Writable<boolean> = writable(true);
+export let minImpactCount: Writable<number> = writable(500);
 
 export function saveCurrentProject() {
   const projectID = get(currentProjectID)!;

--- a/web/src/stores.ts
+++ b/web/src/stores.ts
@@ -92,6 +92,7 @@ export let routePtA: Writable<LngLat> = writable(new LngLat(0, 0));
 export let routePtB: Writable<LngLat> = writable(new LngLat(0, 0));
 export let oneDestination: Writable<LngLat> = writable(new LngLat(0, 0));
 export let mainRoadPenalty: Writable<number> = writable(1.0);
+export let fastSample: Writable<boolean> = writable(true);
 // A way for different components to know when internal app state has changed
 // and they might need to rerender
 export let mutationCounter: Writable<number> = writable(1);

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -265,22 +265,29 @@ export class Backend {
     return JSON.parse(this.inner.impactToOneDestination(pt.lng, pt.lat));
   }
 
-  predictImpact(): FeatureCollection<
+  predictImpact(
+    fastSample: boolean,
+  ): FeatureCollection<
     LineString,
     { id: number; before: number; after: number }
   > & { max_count: number } {
-    return JSON.parse(this.inner.predictImpact());
+    return JSON.parse(this.inner.predictImpact(fastSample));
   }
 
-  getImpactsOnRoad(road: number): Array<{
+  getImpactsOnRoad(
+    road: number,
+    fastSample: boolean,
+  ): Array<{
     count: number;
     before: Feature<LineString, { kind: "before" }> | null;
     after: Feature<LineString, { kind: "after" }> | null;
   }> {
-    return JSON.parse(this.inner.getImpactsOnRoad(road)).map((x: any) => {
-      let [count, before, after] = x;
-      return { count, before, after };
-    });
+    return JSON.parse(this.inner.getImpactsOnRoad(road, fastSample)).map(
+      (x: any) => {
+        let [count, before, after] = x;
+        return { count, before, after };
+      },
+    );
   }
 
   getAllNeighbourhoods(): FeatureCollection<

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -272,15 +272,15 @@ export class Backend {
     return JSON.parse(this.inner.predictImpact());
   }
 
-  getImpactsOnRoad(
-    road: number,
-  ): Array<
-    [
-      Feature<LineString, { kind: "before" }> | null,
-      Feature<LineString, { kind: "after" }> | null,
-    ]
-  > {
-    return JSON.parse(this.inner.getImpactsOnRoad(road));
+  getImpactsOnRoad(road: number): Array<{
+    count: number;
+    before: Feature<LineString, { kind: "before" }> | null;
+    after: Feature<LineString, { kind: "after" }> | null;
+  }> {
+    return JSON.parse(this.inner.getImpactsOnRoad(road)).map((x: any) => {
+      let [count, before, after] = x;
+      return { count, before, after };
+    });
   }
 
   getAllNeighbourhoods(): FeatureCollection<

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -265,23 +265,11 @@ export class Backend {
     return JSON.parse(this.inner.impactToOneDestination(pt.lng, pt.lat));
   }
 
-  predictImpact(
-    fastSample: boolean,
-  ): FeatureCollection<
-    LineString,
-    { id: number; before: number; after: number }
-  > & { max_count: number } {
+  predictImpact(fastSample: boolean): Impact {
     return JSON.parse(this.inner.predictImpact(fastSample));
   }
 
-  getImpactsOnRoad(
-    road: number,
-    fastSample: boolean,
-  ): Array<{
-    count: number;
-    before: Feature<LineString, { kind: "before" }> | null;
-    after: Feature<LineString, { kind: "after" }> | null;
-  }> {
+  getImpactsOnRoad(road: number, fastSample: boolean): ImpactOnRoad[] {
     return JSON.parse(this.inner.getImpactsOnRoad(road, fastSample)).map(
       (x: any) => {
         let [count, before, after] = x;
@@ -320,6 +308,17 @@ export class Backend {
   getPOIs(): FeatureCollection<Point, { name?: string; kind: string }> {
     return JSON.parse(this.inner.getPOIs());
   }
+}
+
+export type Impact = FeatureCollection<
+  LineString,
+  { id: number; before: number; after: number }
+> & { max_count: number };
+
+export interface ImpactOnRoad {
+  count: number;
+  before: Feature<LineString, { kind: "before" }> | null;
+  after: Feature<LineString, { kind: "after" }> | null;
 }
 
 type TurnRestrictionKind =


### PR DESCRIPTION
Parts of #36 and #129.

- Impact prediction now has a loading screen to explain frozenness. If/when we manage to plumb progress info from the backend, this'd be the place to show it
- Link to the debug demand UI, reframing it slightly, since it does seem useful
- Let the user choose to either get a very fast-and-inaccurate prediction, or a slower-but-more-detailed prediction. We either sample one A -> B route from each data zone pair, or use as many points as the OD data says to.

Before, with the sampling, the impact of some changes to the center of Dundee:
![image](https://github.com/user-attachments/assets/c3bb68ea-bd09-4388-a78c-18958f4c782f)

After, without sampling, the visualization gets EXTREMELY noisy. Trips start and end all over the place, so practically every road sees some kind of change:
![image](https://github.com/user-attachments/assets/cb29b6e4-efd2-431c-a884-e3be6618bf1c)

But actually, many of the changes are not interesting. A road going from 9 trips to 0 is a huge relative change, but in absolute scale, it doesn't matter -- that's basically an empty street. So give the user a filter to ignore a changed road if the before and after count are both below the threshold:
![image](https://github.com/user-attachments/assets/b86113b5-c430-4a8f-9dd5-9956f47635b0)
This defaults to 500, but I'll work with Cici to refine a better default that signifies "so little traffic per day that it doesn't matter". Maybe it's a different threshold for residential vs main roads.

The correctness of all of these results is still in question due to #243.