### PR TITLE
Only generate boundaries within settlements.

### DIFF
--- a/backend/benches/boundary_stats.rs
+++ b/backend/benches/boundary_stats.rs
@@ -4,8 +4,8 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn benchmark_build_map_model(c: &mut Criterion) {
     for (fixture, expected_population_zones, expected_generated_boundaries) in [
-        (NeighbourhoodFixture::INVERNESS, 325, 8958),
-        (NeighbourhoodFixture::DUNDEE, 200, 240),
+        (NeighbourhoodFixture::INVERNESS, 325, 390),
+        (NeighbourhoodFixture::DUNDEE, 200, 232),
     ] {
         // Do the file i/o (reading OSM.xml) outside of the bench loop
         let (neighbourhood, map) = fixture.neighbourhood_map().unwrap();

--- a/backend/benches/boundary_stats.rs
+++ b/backend/benches/boundary_stats.rs
@@ -4,8 +4,8 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn benchmark_build_map_model(c: &mut Criterion) {
     for (fixture, expected_population_zones, expected_generated_boundaries) in [
-        (NeighbourhoodFixture::INVERNESS, 325, 390),
-        (NeighbourhoodFixture::DUNDEE, 200, 232),
+        (NeighbourhoodFixture::INVERNESS, 325, 209),
+        (NeighbourhoodFixture::DUNDEE, 200, 219),
     ] {
         // Do the file i/o (reading OSM.xml) outside of the bench loop
         let (neighbourhood, map) = fixture.neighbourhood_map().unwrap();

--- a/backend/benches/boundary_stats.rs
+++ b/backend/benches/boundary_stats.rs
@@ -4,8 +4,8 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 fn benchmark_build_map_model(c: &mut Criterion) {
     for (fixture, expected_population_zones, expected_generated_boundaries) in [
-        (NeighbourhoodFixture::INVERNESS, 325, 209),
-        (NeighbourhoodFixture::DUNDEE, 200, 219),
+        (NeighbourhoodFixture::INVERNESS, 325, 440),
+        (NeighbourhoodFixture::DUNDEE, 200, 253),
     ] {
         // Do the file i/o (reading OSM.xml) outside of the bench loop
         let (neighbourhood, map) = fixture.neighbourhood_map().unwrap();

--- a/backend/src/create.rs
+++ b/backend/src/create.rs
@@ -155,19 +155,7 @@ pub fn create_from_osm(
 
     let context_data = context_data_wgs84.map(|mut context_data_wgs84| {
         context_data_wgs84.pois.extend(osm.pois);
-
-        for population_zone in &mut context_data_wgs84.population_zones {
-            graph
-                .mercator
-                .to_mercator_in_place(&mut population_zone.geometry);
-        }
-        for stats19_collision in &mut context_data_wgs84.stats19_collisions {
-            graph.mercator.to_mercator_in_place(stats19_collision);
-        }
-        for poi in &mut context_data_wgs84.pois {
-            graph.mercator.to_mercator_in_place(&mut poi.point);
-        }
-        context_data_wgs84.into_prepared()
+        context_data_wgs84.into_prepared(&graph.mercator)
     });
 
     // Add in a bit

--- a/data_prep/scotland/build_cnt_lad_settlements.sh
+++ b/data_prep/scotland/build_cnt_lad_settlements.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -ex
+download_to_subdir() {
+  local subdir=$1
+  local url=$2
+  mkdir -p "$subdir"
+  (wget -P "$subdir" --timestamping "$url" && echo "✅ $url") \
+    || echo "❌ Download failed: $url"
+}
+if [ ! -d "input/scotland_settlements_shapefiles" ]; then
+    download_to_subdir tmp https://www.nrscotland.gov.uk/media/2hsoadnx/shapefiles.zip
+    unzip tmp/shapefiles.zip -d input/scotland_settlements_shapefiles
+fi
+
+# ogrinfo -so input/scotland_settlements_shapefiles/Settlements_2020_MHW.shp Settlements_2020_MHW
+
+# Create GPKG and load settlements
+# Assuming settlements is in EPSG:27700 (British National Grid)
+ogr2ogr -f GPKG tmp/lad_settlements.gpkg \
+    input/scotland_settlements_shapefiles/Settlements_2020_MHW.shp \
+    -nlt PROMOTE_TO_MULTI \
+    -nln settlements
+
+# Add LAD boundaries to GPKG but reproject to match settlements projection
+ogr2ogr -f GPKG -update -append tmp/lad_settlements.gpkg \
+    boundaries.geojson \
+    -t_srs EPSG:27700 \
+    -nln lads
+
+# Create output directory if it doesn't exist
+mkdir -p output
+
+ogr2ogr -f GeoJSON tmp/lad_settlements.geojson tmp/lad_settlements.gpkg \
+  -sql "SELECT lads.name, lads.kind, ST_Union(ST_Intersection(lads.geom, settlements.geom)) AS geom
+        FROM lads
+        JOIN settlements
+        ON ST_Intersects(lads.geom, settlements.geom)
+        GROUP BY lads.name
+        " \
+  -t_srs EPSG:4326 \
+  -nlt PROMOTE_TO_MULTI \
+  -nln lad_settlements
+


### PR DESCRIPTION
An attempt at https://github.com/a-b-street/ltn/issues/254#issuecomment-2744699163

FIXES #158 
FIXES #254

**before:** Largely rural areas (Highlands) had many huge, improbably, suggested boundaries, and ~30s load time.

<img width="785" alt="Screenshot 2025-03-25 at 09 18 28" src="https://github.com/user-attachments/assets/c3790270-db02-450e-9613-885dc69f73c9" />

Though it did look kind of fun.

**after:**
<img width="808" alt="Screenshot 2025-03-25 at 09 18 08" src="https://github.com/user-attachments/assets/9746f4e8-c35e-4744-bb01-f059f0456bc5" />

Zooming in to Inverness
<img width="1388" alt="Screenshot 2025-03-25 at 09 18 15" src="https://github.com/user-attachments/assets/6db9ee28-a04b-4bb4-a80d-03aeeb99a16c" />


Denser areas, e.g. Glasgow City are more or less unaffected by this change:

**before:**
<img width="758" alt="Screenshot 2025-03-25 at 09 19 42" src="https://github.com/user-attachments/assets/86252a7c-384c-42a5-a0d5-ebd38bb75f55" />

**after:** Some of the outskirt neighborhoods seem to have an additional split, presumably when a previously "severance based" boundary is now split by the settlement boundary. I think that's fine:

<img width="1091" alt="Screenshot 2025-03-25 at 09 19 25" src="https://github.com/user-attachments/assets/1cafdf62-a190-4b3c-9116-c6fb1ff59e38" />

If we decide to, I think adding buffering would be a straight forward change on top of this. But in my own QA, I haven't yet found cases where it would be helpful.

Performance diff:

```
inverness/generate auto boundaries (and stats)
                        time:   [4.5871 s 4.6247 s 4.6708 s]
                        change: [-79.509% -78.969% -78.414%] (p = 0.00 < 0.05)
                        Performance has improved.
dundee/generate auto boundaries (and stats)
                        time:   [147.92 ms 148.44 ms 149.01 ms]
                        change: [+107.50% +108.33% +109.26%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

The fast ones got quite a bit slower (relatively), but I think are still fast enough. While the slow ones got a **lot** faster. I think this puts us into an acceptable range for Highlands.