### PR TITLE
Legend touchups

### DIFF
--- a/web/src/common/QualitativeLegend.svelte
+++ b/web/src/common/QualitativeLegend.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  export let labelColors: Record<string, string>;
+  export let swatchClass: "rectangle" | "circle" = "rectangle";
+  export let itemsPerRow: 1 | 2 | 3 | 4 = 2;
+  let gridItemWidth = `${100 / itemsPerRow}%`;
+</script>
+
+<div
+  style="display: grid; grid-template-columns: repeat(auto-fill, calc({gridItemWidth} - 10px)); gap: 10px;"
+>
+  {#each Object.entries(labelColors) as [label, color]}
+    <div style="display: flex; align-items: center; gap: 6px;">
+      <span class="color-swatch {swatchClass}" style:background={color} />
+      {label}
+    </div>
+  {/each}
+</div>
+
+<style>
+  .color-swatch.circle {
+    height: 20px;
+    width: 20px;
+    border-radius: 10px;
+    border: 1px solid black;
+  }
+  .color-swatch.rectangle {
+    height: 16px;
+    width: 24px;
+    border: 1px solid #888;
+  }
+</style>

--- a/web/src/common/SequentialLegend.svelte
+++ b/web/src/common/SequentialLegend.svelte
@@ -3,6 +3,7 @@
   type IntoLabel = string | number;
   export let labels: { limits: IntoLabel[] } | { buckets: IntoLabel[] };
   export let decimalPlaces = 0;
+  export let fullWidthBucketLegend = false;
 
   let intoLabels: IntoLabel[] = [];
   if ("limits" in labels) {
@@ -24,26 +25,29 @@
   });
 </script>
 
-<div class="colors">
-  {#each colorScale as color}
-    <span class="bucket" style="background: {color};">&nbsp;</span>
-  {/each}
-</div>
-
 <div
-  class="labels"
+  class:full-width-bucket-legend={fullWidthBucketLegend}
   class:bucketed={labels.hasOwnProperty("buckets")}
   class:limits={labels.hasOwnProperty("limits")}
 >
-  {#each labelTexts as labelText}
-    <span>{labelText}</span>
-  {/each}
+  <div class="colors">
+    {#each colorScale as color}
+      <span class="bucket" style="background: {color};">&nbsp;</span>
+    {/each}
+  </div>
+
+  <div class="labels">
+    {#each labelTexts as labelText}
+      <span>{labelText}</span>
+    {/each}
+  </div>
 </div>
 
 <style>
   .colors {
     display: flex;
     justify-content: space-around;
+    height: 20px;
   }
 
   .colors .bucket {
@@ -52,13 +56,16 @@
     /* "collapse" the double border between the inner buckets */
     border-left: 0;
   }
+
   .colors .bucket:first-child {
     border-left: 1px solid black;
   }
 
   /* align the colors so that the limits labels fall between color bucket */
-  .colors::before,
-  .colors::after {
+  :not(.full-width-bucket-legend) .colors::before,
+  :not(.full-width-bucket-legend) .colors::after,
+  .bucketed:not(.full-width-bucket-legend) .labels::before,
+  .bucketed:not(.full-width-bucket-legend) .labels::after {
     content: "";
     flex: 0.5;
   }
@@ -71,10 +78,5 @@
 
   .labels * {
     flex: 1;
-  }
-  .labels.bucketed::before,
-  .labels.bucketed::after {
-    content: "";
-    flex: 0.5;
   }
 </style>

--- a/web/src/common/index.ts
+++ b/web/src/common/index.ts
@@ -13,6 +13,7 @@ export { default as DotMarker } from "./DotMarker.svelte";
 export { default as HelpButton } from "./HelpButton.svelte";
 export { default as Link } from "./Link.svelte";
 export { default as PrevNext } from "./PrevNext.svelte";
+export { default as QualitativeLegend } from "./QualitativeLegend.svelte";
 export { default as SequentialLegend } from "./SequentialLegend.svelte";
 export { default as StreetView } from "./StreetView.svelte";
 export { layerId } from "./zorder";

--- a/web/src/context/CBD.svelte
+++ b/web/src/context/CBD.svelte
@@ -62,6 +62,7 @@
     <SequentialLegend
       colorScale={Object.values(levelOfServiceColors)}
       labels={{ buckets: Object.keys(levelOfServiceColors) }}
+      fullWidthBucketLegend
     />
   </div>
 

--- a/web/src/context/CBD.svelte
+++ b/web/src/context/CBD.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { LineLayer, VectorTileSource } from "svelte-maplibre";
-  import { QualitativeLegend } from "svelte-utils";
   import { constructMatchExpression } from "svelte-utils/map";
   import {
     ContextLayerButton,
     layerId,
+    QualitativeLegend,
     roadLineWidth,
     SequentialLegend,
   } from "../common";
@@ -59,7 +59,10 @@
 
 <ContextLayerButton bind:show={showLos} label="Level of Service">
   <div slot="legend">
-    <QualitativeLegend colors={levelOfServiceColors} horiz />
+    <SequentialLegend
+      colorScale={Object.values(levelOfServiceColors)}
+      labels={{ buckets: Object.keys(levelOfServiceColors) }}
+    />
   </div>
 
   <p slot="help">
@@ -74,7 +77,7 @@
 
 <ContextLayerButton bind:show={showExistingInfra} label="Cycle infrastructure">
   <div slot="legend">
-    <QualitativeLegend colors={infraTypeColors} horiz />
+    <QualitativeLegend labelColors={infraTypeColors} />
   </div>
 
   <p slot="help">

--- a/web/src/context/POIs.svelte
+++ b/web/src/context/POIs.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
   import { CircleLayer, GeoJSON } from "svelte-maplibre";
-  import { QualitativeLegend } from "svelte-utils";
   import { constructMatchExpression, Popup } from "svelte-utils/map";
-  import { ContextLayerButton, layerId } from "../common";
+  import { ContextLayerButton, layerId, QualitativeLegend } from "../common";
   import { backend } from "../stores";
 
   let show = false;
 
   // https://colorbrewer2.org/#type=qualitative&scheme=Accent&n=5
-  let colors = {
+  let labelColors = {
     School: "#7fc97f",
     GP: "#beaed4",
     Hospital: "#fdc086",
@@ -19,7 +18,7 @@
 
 <ContextLayerButton label="POIs" bind:show>
   <div slot="legend">
-    <QualitativeLegend {colors} horiz />
+    <QualitativeLegend {labelColors} swatchClass="circle" />
   </div>
 
   <p slot="help">
@@ -59,7 +58,7 @@
       paint={{
         "circle-color": constructMatchExpression(
           ["get", "kind"],
-          colors,
+          labelColors,
           "black",
         ),
         "circle-radius": 10,

--- a/web/src/context/Stats19.svelte
+++ b/web/src/context/Stats19.svelte
@@ -5,9 +5,8 @@
     VectorTileSource,
     type LayerClickInfo,
   } from "svelte-maplibre";
-  import { QualitativeLegend } from "svelte-utils";
   import { makeRamp, Popup } from "svelte-utils/map";
-  import { ContextLayerButton, layerId } from "../common";
+  import { ContextLayerButton, layerId, QualitativeLegend } from "../common";
   import { assetUrl } from "../stores";
 
   let show = false;
@@ -90,9 +89,9 @@
   let seriousColor = "#1F9EB7";
   let slightColor = "#CDE594";
   let severityLegend = {
-    Fatal: fatalColor,
-    Serious: seriousColor,
     Slight: slightColor,
+    Serious: seriousColor,
+    Fatal: fatalColor,
   };
 </script>
 
@@ -166,7 +165,11 @@
         <input type="number" min={2017} max={2023} bind:value={state.maxYear} />
       </label>
     </fieldset>
-    <QualitativeLegend colors={severityLegend} horiz />
+    <QualitativeLegend
+      labelColors={severityLegend}
+      swatchClass="circle"
+      itemsPerRow={3}
+    />
   </div>
 </ContextLayerButton>
 


### PR DESCRIPTION
Fixes #231 

Addresses some of the crowding issues in the current legend layout.

The legend color swatches are now circles for POI and Collision data, which matches their cartographic symbology.


---
**POI before:** crowded squares

<img width="673" alt="Screenshot 2025-03-24 at 15 25 04" src="https://github.com/user-attachments/assets/94e2e007-a6b6-4e14-9869-11379d5aa199" />

**POI after:** less crowded circles

<img width="500" alt="Screenshot 2025-03-24 at 15 26 07" src="https://github.com/user-attachments/assets/1f1f7533-4ee2-4e7d-a471-2068e6741f47" />

---
**LoS before:** Labels are under limits

<img width="337" alt="Screenshot 2025-03-24 at 15 26 57" src="https://github.com/user-attachments/assets/504332cf-0ed0-44a0-9976-7490a13bcf40" />

**LoS after:** Labels are under buckets

<img width="337" alt="Screenshot 2025-03-24 at 15 27 44" src="https://github.com/user-attachments/assets/30ff5362-14a2-4954-84ec-9ddd1d6ffd36" />

---

**Cycle infrastructure before:** crowded, label alignment is a little rough

<img width="338" alt="Screenshot 2025-03-24 at 15 28 56" src="https://github.com/user-attachments/assets/47386669-7766-4796-be9f-3d69e7da10e8" />

**Cycle infrastructure after:** less crowded

<img width="344" alt="Screenshot 2025-03-24 at 15 29 03" src="https://github.com/user-attachments/assets/422de079-dabf-4775-ae3e-49b4df30a439" />

---

**Collisions before:** not bad before (though I'd center the labels)

<img width="460" alt="Screenshot 2025-03-24 at 15 31 40" src="https://github.com/user-attachments/assets/9c23d41e-18f6-4e14-b919-a4a274956502" />

**Collisions after:** legend symbology matches map (circles). I also reversed the ordering - it seemed more intuitive.

<img width="553" alt="Screenshot 2025-03-24 at 15 32 35" src="https://github.com/user-attachments/assets/1deca3ec-85b3-44f7-8e66-9651dadb94e8" />

