### PR TITLE
FIX: "pick neighbourhood" shouldn't look disabled

### DIFF
--- a/web/src/CntChooseArea.svelte
+++ b/web/src/CntChooseArea.svelte
@@ -10,7 +10,7 @@
   } from "svelte-maplibre";
   import { Popup } from "svelte-utils/map";
   import boundariesUrl from "../assets/cnt_boundaries.geojson?url";
-  import { Link, prettyPrintStudyAreaName } from "./common";
+  import { Link, prettyPrintStudyAreaName, Style } from "./common";
   import { mode, projectStorage } from "./stores";
   import { loadProject } from "./title/loader";
 
@@ -92,8 +92,8 @@
 <GeoJSON data={gj} generateId>
   <FillLayer
     paint={{
-      "fill-color": "rgb(200, 100, 240)",
-      "fill-outline-color": "rgb(200, 100, 240)",
+      "fill-color": Style.mapFeature.hover.backgroundColor,
+      "fill-outline-color": Style.mapFeature.hover.backgroundColor,
       "fill-opacity": hoverStateFilter(0.0, 0.5),
     }}
     beforeId="Road labels"
@@ -108,7 +108,7 @@
 
   <LineLayer
     paint={{
-      "line-color": "rgb(200, 100, 240)",
+      "line-color": Style.mapFeature.hover.backgroundColor,
       "line-width": 2.5,
     }}
     beforeId="Road labels"

--- a/web/src/DebugNeighbourhoodMode.svelte
+++ b/web/src/DebugNeighbourhoodMode.svelte
@@ -12,8 +12,7 @@
   import { Popup } from "svelte-utils/map";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
   import BackButton from "./BackButton.svelte";
-  import { layerId, Link, mapMetersToPixels, PrevNext } from "./common";
-  import { Style } from "./common/colors";
+  import { layerId, Link, mapMetersToPixels, PrevNext, Style } from "./common";
   import type { IntersectionFeature } from "./common/Intersection";
   import {
     CellLayer,

--- a/web/src/PickNeighbourhoodMode.svelte
+++ b/web/src/PickNeighbourhoodMode.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { FeatureCollection } from "geojson";
   import { CirclePlus, Pencil, Trash2 } from "lucide-svelte";
-  import type { DataDrivenPropertyValueSpecification } from "maplibre-gl";
+  import { type DataDrivenPropertyValueSpecification } from "maplibre-gl";
   import {
     FillLayer,
     GeoJSON,
@@ -12,7 +12,7 @@
   import { downloadGeneratedFile, notNull } from "svelte-utils";
   import { Popup } from "svelte-utils/map";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
-  import { HelpButton, layerId, Link } from "./common";
+  import { HelpButton, layerId, Link, Style } from "./common";
   import { pickNeighbourhoodName } from "./common/pick_names";
   import { ModalFilterLayer } from "./layers";
   import {
@@ -109,7 +109,7 @@
   function fillColor(
     selectedPrioritization: Prioritization,
   ): DataDrivenPropertyValueSpecification<string> {
-    let highlightedColor = "yellow";
+    let highlightedColor = Style.mapFeature.hover.backgroundColor;
     let color = prioritizationFillColor(
       { none: highlightedColor },
       selectedPrioritization,
@@ -126,13 +126,13 @@
   function fillOpacity(
     selectedPrioritization: Prioritization,
   ): DataDrivenPropertyValueSpecification<number> {
-    let highlightedOpacity = 0.5;
+    let highlightedOpacity = 0.7;
     let styles: Record<string, DataDrivenPropertyValueSpecification<number>> = {
       none: [
         "case",
         ["==", ["feature-state", "highlight"], "yes"],
         highlightedOpacity,
-        hoverStateFilter(0.0, highlightedOpacity),
+        hoverStateFilter(0.3, highlightedOpacity),
       ],
       area: hoverStateFilter(0.7, 0.9),
       density: hoverStateFilter(0.7, 0.9),
@@ -325,6 +325,6 @@
 
 <style>
   li.highlighted {
-    background-color: #f0fcaa;
+    background-color: rgba(72, 96, 202, 0.15);
   }
 </style>

--- a/web/src/PickNeighbourhoodMode.svelte
+++ b/web/src/PickNeighbourhoodMode.svelte
@@ -7,6 +7,7 @@
     GeoJSON,
     hoverStateFilter,
     JoinedData,
+    LineLayer,
   } from "svelte-maplibre";
   import { downloadGeneratedFile, notNull } from "svelte-utils";
   import { Popup } from "svelte-utils/map";
@@ -108,15 +109,15 @@
   function fillColor(
     selectedPrioritization: Prioritization,
   ): DataDrivenPropertyValueSpecification<string> {
+    let highlightedColor = "yellow";
     let color = prioritizationFillColor(
-      { none: "black" },
+      { none: highlightedColor },
       selectedPrioritization,
     );
-
     return [
       "case",
       ["==", ["feature-state", "highlight"], "yes"],
-      "yellow",
+      highlightedColor,
       // @ts-expect-error MapLibre expression types are weird, but this really does work
       color,
     ];
@@ -125,15 +126,22 @@
   function fillOpacity(
     selectedPrioritization: Prioritization,
   ): DataDrivenPropertyValueSpecification<number> {
-    return {
-      none: hoverStateFilter(0.3, 0.5),
+    let highlightedOpacity = 0.5;
+    let styles: Record<string, DataDrivenPropertyValueSpecification<number>> = {
+      none: [
+        "case",
+        ["==", ["feature-state", "highlight"], "yes"],
+        highlightedOpacity,
+        hoverStateFilter(0.0, highlightedOpacity),
+      ],
       area: hoverStateFilter(0.7, 0.9),
       density: hoverStateFilter(0.7, 0.9),
       simd: hoverStateFilter(0.7, 0.9),
       stats19: hoverStateFilter(0.7, 0.9),
       pois: hoverStateFilter(0.7, 0.9),
       car_ownership: hoverStateFilter(0.7, 0.9),
-    }[selectedPrioritization];
+    };
+    return styles[selectedPrioritization];
   }
 </script>
 
@@ -260,6 +268,26 @@
         idCol="name"
       />
 
+      <LineLayer
+        filter={["==", ["get", "kind"], "boundary"]}
+        {...layerId("neighbourhood-boundaries-selected-outline", false)}
+        manageHoverState={false}
+        paint={{
+          "line-color": "black",
+          "line-width": 4,
+          "line-dasharray": [2, 2],
+        }}
+      />
+      <LineLayer
+        filter={["==", ["get", "kind"], "boundary"]}
+        {...layerId("neighbourhood-boundaries-selected-outline-base", false)}
+        manageHoverState={false}
+        paint={{
+          "line-color": "white",
+          "line-width": 8,
+          "line-opacity": 0.7,
+        }}
+      />
       <FillLayer
         {...layerId("neighbourhood-boundaries", false)}
         filter={["==", ["get", "kind"], "boundary"]}

--- a/web/src/common/colors.ts
+++ b/web/src/common/colors.ts
@@ -59,7 +59,7 @@ export const signGreen = "#0C793A";
 export const Style = {
   mapFeature: {
     hover: {
-      backgroundColor: "blue",
+      backgroundColor: "rgb(72, 96, 202)",
     },
   },
 };

--- a/web/src/common/index.ts
+++ b/web/src/common/index.ts
@@ -17,6 +17,7 @@ export { default as QualitativeLegend } from "./QualitativeLegend.svelte";
 export { default as SequentialLegend } from "./SequentialLegend.svelte";
 export { default as StreetView } from "./StreetView.svelte";
 export { layerId } from "./zorder";
+export { Style } from "./colors";
 
 // TS fix for the imprecise geojson types
 export function gjPosition(pt: number[]): [number, number] {

--- a/web/src/layers/EditableIntersectionLayer.svelte
+++ b/web/src/layers/EditableIntersectionLayer.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { getContext } from "svelte";
   import { CircleLayer, hoverStateFilter, Popup } from "svelte-maplibre";
-  import { layerId, mapMetersToPixels } from "../common";
-  import { Style } from "../common/colors";
+  import { layerId, mapMetersToPixels, Style } from "../common";
   import {
     Intersection,
     type IntersectionFeature,

--- a/web/src/layers/NeighbourhoodRoadLayer.svelte
+++ b/web/src/layers/NeighbourhoodRoadLayer.svelte
@@ -29,7 +29,11 @@
       return ["get", "color"];
     }
     if (style == "edits") {
-      return ["case", ["get", "edited"], signGreen, "white"];
+      return hoverStateFilter(
+        // @ts-expect-error hoverStateFilter is not properly typed - it should accept an expression
+        ["case", ["get", "edited"], signGreen, "white"],
+        Style.mapFeature.hover.backgroundColor,
+      );
     }
     if (style == "speeds") {
       return makeRamp(
@@ -43,8 +47,9 @@
       return hoverStateFilter("white", "blue");
     }
 
+    console.assert(style == "shortcuts");
     return hoverStateFilter(
-      // @ts-expect-error TODO Fix upstream types
+      // @ts-expect-error hoverStateFilter is not properly typed - it should accept an expression
       [
         "interpolate-hcl",
         ["linear"],
@@ -128,7 +133,10 @@
   filter={["==", ["get", "kind"], "main_road"]}
   paint={{
     "line-width": lineWidth($thickRoadsForShortcuts, gj.maxShortcuts, 4),
-    "line-color": hoverStateFilter("gray", "blue"),
+    "line-color": hoverStateFilter(
+      "gray",
+      Style.mapFeature.hover.backgroundColor,
+    ),
     "line-opacity": hoverStateFilter(1.0, 0.5),
   }}
   layout={{


### PR DESCRIPTION
FIXES #237

**before:** On the pick neighbourhood screen currently, the pickable areas are colored gray, which communicates "disabled". E.g. we use the same gray color as a mask to "blot out" the rest of the world outside of the study area.

<img width="922" alt="Screenshot 2025-03-25 at 11 43 18" src="https://github.com/user-attachments/assets/a44d6ff3-caeb-4162-b562-d55c770fc9a5" />

**after:**

https://github.com/user-attachments/assets/375f7795-ca20-4464-bd7b-8e0ee269b3c8

Now we use the same boundary outline style as used when building the neighbourhood boundary.

I think it's nice to throw back to the same design we use elsewhere to communicate neighbourhood boundaries.

I also think it's nice to match the "highlight" color on the map with the color we use in the sidebar when hovering.

I also like that the lack of mask when *not* hovered means you can see the interior of the neighbourhoods.

The major downside to this approach is that without a visible "fill", it might not be obvious enough that the neighbourhoods represent a 2-d area. 

I could easily be convinced to add a low-opacity fill to the unhovered state. It shouldn't be gray though. Maybe blue like we show for the LAD boundaries on the CNT title page?

Or maybe it's fine as phrased. What do you think?

