### PR TITLE
Suggest default project and neighborhood names, don't allow picking blank.

### DIFF
--- a/web/src/AddNeighbourhoodMode.svelte
+++ b/web/src/AddNeighbourhoodMode.svelte
@@ -27,8 +27,10 @@
   import {
     appFocus,
     backend,
+    currentProjectID,
     map,
     mode,
+    projectStorage,
     returnToChooseProject,
     saveCurrentProject,
   } from "./stores";
@@ -133,10 +135,14 @@
   }
 
   function createNeighbourhood(selectedBoundary: GeneratedBoundaryFeature) {
+    let defaultName = $projectStorage.nextAvailableNeighbourhoodName(
+      $currentProjectID!,
+    );
+
     let name = pickNeighbourhoodName(
       $backend!,
       "What do you want to name the neighbourhood?",
-      "",
+      defaultName,
     );
     if (!name) {
       return;

--- a/web/src/CntChooseArea.svelte
+++ b/web/src/CntChooseArea.svelte
@@ -42,17 +42,28 @@
   }
 
   async function newFile(studyAreaName: string) {
-    let projectName = "";
+    let projectName;
     let created = false;
     while (!created) {
-      projectName =
-        window.prompt(
-          `Please pick a project name to create in ${prettyPrintStudyAreaName(studyAreaName)}`,
-          projectName,
-        ) || "";
-      if (projectName == "") {
-        // If the user leaves this blank or presses cancel, stop prompting them.
+      let defaultName: string | null =
+        projectName ||
+        $projectStorage.nextAvailableProjectName(
+          prettyPrintStudyAreaName(studyAreaName),
+        );
+      projectName = window.prompt(
+        `Please pick a project name to create in ${prettyPrintStudyAreaName(studyAreaName)}`,
+        defaultName,
+      );
+      if (projectName === null) {
+        // If the user presses cancel, stop prompting them.
         return;
+      }
+      projectName = projectName.trim();
+      if (projectName === "") {
+        window.alert(
+          "Project name cannot be blank; Please pick a name or cancel.",
+        );
+        continue;
       }
       activityIndicatorText = `Loading pre-clipped OSM area ${prettyPrintStudyAreaName(studyAreaName)}`;
       try {

--- a/web/src/common/ProjectStorage.test.ts
+++ b/web/src/common/ProjectStorage.test.ts
@@ -1,5 +1,6 @@
 import type { FeatureCollection } from "geojson";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NeighbourhoodDefinitionFeature } from "../wasm";
 import {
   Database,
   ProjectStorage,
@@ -265,6 +266,60 @@ describe("ProjectStorage", () => {
       projectStorage.createEmptyProject("Test Project (2)", "TestArea");
       expect(projectStorage.nextAvailableProjectName("Test Project")).toBe(
         "Test Project (3)",
+      );
+    });
+  });
+
+  describe("nextAvailableNeighbourhoodName", () => {
+    it("should return un-suffixed name when there are no neighbourhoods", () => {
+      let projectID = projectStorage.createEmptyProject(
+        "Test Project",
+        "TestArea",
+      );
+      expect(projectStorage.nextAvailableNeighbourhoodName(projectID)).toBe(
+        "Test Project LTN",
+      );
+    });
+
+    it("should add a unique suffix if the name is already taken", () => {
+      let projectID = projectStorage.createEmptyProject(
+        "Test Project",
+        "TestArea",
+      );
+      let existingNeighbourhood: NeighbourhoodDefinitionFeature = {
+        type: "Feature",
+        geometry: { type: "Polygon", coordinates: [] },
+        properties: {
+          kind: "boundary",
+          name: "Test Project LTN",
+        },
+      };
+      let project = projectStorage.project(projectID);
+      project.features.push(existingNeighbourhood);
+      projectStorage.saveProject(projectID, project);
+      expect(projectStorage.nextAvailableNeighbourhoodName(projectID)).toBe(
+        "Test Project LTN #2",
+      );
+    });
+
+    it("should return un-suffixed name as long as any existing projects don't have that name.", () => {
+      let projectID = projectStorage.createEmptyProject(
+        "Test Project",
+        "TestArea",
+      );
+      let existingNeighbourhood: NeighbourhoodDefinitionFeature = {
+        type: "Feature",
+        geometry: { type: "Polygon", coordinates: [] },
+        properties: {
+          kind: "boundary",
+          name: "Custom neighbourhood name",
+        },
+      };
+      let project = projectStorage.project(projectID);
+      project.features.push(existingNeighbourhood);
+      projectStorage.saveProject(projectID, project);
+      expect(projectStorage.nextAvailableNeighbourhoodName(projectID)).toBe(
+        "Test Project LTN",
       );
     });
   });

--- a/web/src/common/ProjectStorage.test.ts
+++ b/web/src/common/ProjectStorage.test.ts
@@ -247,4 +247,25 @@ describe("ProjectStorage", () => {
       ).toBe(false);
     });
   });
+
+  describe("nextAvailableProjectName", () => {
+    it("should return the same name if it's available", () => {
+      expect(projectStorage.nextAvailableProjectName("Test Project")).toBe(
+        "Test Project",
+      );
+    });
+    it("should return a unique name if the name is already taken", () => {
+      projectStorage.createEmptyProject("Test Project", "TestArea");
+      expect(projectStorage.nextAvailableProjectName("Test Project")).toBe(
+        "Test Project (2)",
+      );
+    });
+    it("should return a unique name if the name is already taken multiple times", () => {
+      projectStorage.createEmptyProject("Test Project", "TestArea");
+      projectStorage.createEmptyProject("Test Project (2)", "TestArea");
+      expect(projectStorage.nextAvailableProjectName("Test Project")).toBe(
+        "Test Project (3)",
+      );
+    });
+  });
 });

--- a/web/src/common/ProjectStorage.ts
+++ b/web/src/common/ProjectStorage.ts
@@ -1,5 +1,6 @@
 import type { FeatureCollection, MultiPolygon, Polygon } from "geojson";
 import type { AppFocus } from "../stores";
+import type { NeighbourhoodDefinitionFeature } from "../wasm";
 
 export type ProjectID = ReturnType<(typeof crypto)["randomUUID"]>;
 export type StudyAreaName = string | undefined;
@@ -171,6 +172,25 @@ export class ProjectStorage {
       } while (this.projectNameAlreadyExists(projectName));
     }
     return projectName;
+  }
+
+  nextAvailableNeighbourhoodName(projectID: ProjectID): string {
+    let project = this.project(projectID);
+    let basename = `${project.project_name} LTN`;
+
+    let neighbourhoods = project.features.filter(
+      (f) => f.properties?.kind == "boundary",
+    ) as Array<NeighbourhoodDefinitionFeature>;
+
+    let neighbourhoodName = basename;
+    let i = 1;
+    while (
+      neighbourhoods.some((n) => n.properties?.name == neighbourhoodName)
+    ) {
+      i++;
+      neighbourhoodName = `${basename} #${i}`;
+    }
+    return neighbourhoodName;
   }
 
   /**

--- a/web/src/common/ProjectStorage.ts
+++ b/web/src/common/ProjectStorage.ts
@@ -161,6 +161,18 @@ export class ProjectStorage {
     return false;
   }
 
+  nextAvailableProjectName(projectName: string): string {
+    if (this.projectNameAlreadyExists(projectName)) {
+      let originalProjectName = projectName;
+      let i = 2;
+      do {
+        projectName = `${originalProjectName} (${i})`;
+        i++;
+      } while (this.projectNameAlreadyExists(projectName));
+    }
+    return projectName;
+  }
+
   /**
    * @throws if the project name already exists
    */

--- a/web/src/common/pick_names.ts
+++ b/web/src/common/pick_names.ts
@@ -16,10 +16,17 @@ export function pickNeighbourhoodName(
 
   while (true) {
     let name = window.prompt(promptMessage, defaultValue);
-    if (!name) {
+    if (name === null) {
+      // User canceled the prompt
       return null;
     }
-    if (used.has(name)) {
+
+    name = name.trim();
+    if (name === "") {
+      window.alert(
+        `Neighbourhood cannot be blank; please pick a name or cancel`,
+      );
+    } else if (used.has(name)) {
       window.alert(
         `There is already a neighbourhood called ${name}; please pick another name`,
       );

--- a/web/src/title/LoadSavedProject.svelte
+++ b/web/src/title/LoadSavedProject.svelte
@@ -58,15 +58,7 @@
     appFocus = appFocus!;
 
     let projectStorage = database.projectStorage(appFocus);
-
-    if (projectStorage.projectNameAlreadyExists(projectName)) {
-      let originalProjectName = projectName;
-      let i = 2;
-      do {
-        projectName = `${originalProjectName} (${i})`;
-        i++;
-      } while (projectStorage.projectNameAlreadyExists(projectName));
-    }
+    projectName = projectStorage.nextAvailableProjectName(projectName)!;
 
     gj.project_name = projectName;
     gj.app_focus = appFocus!;

--- a/web/src/title/NewProjectMode.svelte
+++ b/web/src/title/NewProjectMode.svelte
@@ -58,7 +58,13 @@
       return;
     }
 
-    let projectID = $projectStorage.createEmptyProject(newProjectName, example);
+    let projectID;
+    try {
+      projectID = $projectStorage.createEmptyProject(newProjectName, example);
+    } catch (err) {
+      window.alert(`Couldn't create project: ${err}`);
+      return;
+    }
     loading = `Loading pre-clipped OSM area ${example}`;
     await loadProject(projectID);
     $mode = { mode: "add-neighbourhood" };

--- a/web/src/title/NewProjectMode.svelte
+++ b/web/src/title/NewProjectMode.svelte
@@ -19,7 +19,7 @@
   import { loadProject } from "./loader";
 
   let newProjectName = "";
-  let example = "";
+  let example: string | null = null;
   let exampleAreas: [string, [string, string][]][] = [];
   let loading = "";
 
@@ -54,7 +54,7 @@
   }
 
   export async function loadExample() {
-    if (example == "") {
+    if (!example) {
       return;
     }
 
@@ -62,6 +62,7 @@
     try {
       projectID = $projectStorage.createEmptyProject(newProjectName, example);
     } catch (err) {
+      example = null;
       window.alert(`Couldn't create project: ${err}`);
       return;
     }

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -22,6 +22,15 @@ import type { AppFocus } from "./stores";
 // here aside from parsing and making the API nicer for both the Rust and TS
 // code. This is also a step towards moving to using web workers.
 
+export type NeighbourhoodDefinitionFeature = Feature<
+  Polygon,
+  {
+    name: string;
+    waypoints?: Waypoint[];
+    kind: "boundary";
+  }
+>;
+
 export type NeighbourhoodBoundaryFeature = Feature<
   Polygon,
   {
@@ -39,6 +48,7 @@ export type NeighbourhoodBoundaryFeature = Feature<
 export type GeneratedBoundaryFeature = Feature<
   Polygon,
   {
+    // TODO: these properties went away in the rust code, update this signature.
     touches_big_road: boolean;
     touches_railway: boolean;
     touches_waterway: boolean;

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -48,11 +48,6 @@ export type NeighbourhoodBoundaryFeature = Feature<
 export type GeneratedBoundaryFeature = Feature<
   Polygon,
   {
-    // TODO: these properties went away in the rust code, update this signature.
-    touches_big_road: boolean;
-    touches_railway: boolean;
-    touches_waterway: boolean;
-
     area_km2: number;
     households_with_cars_or_vans: number;
     total_households: number;


### PR DESCRIPTION
FIXES #245 and #249 

We now suggest project and neighbourhood names, which makes the creation process a bit faster and a bit less "daunting" if you don't know what these names are for.

**New flow:**


https://github.com/user-attachments/assets/0135d3d2-10f3-4b4c-bbd1-2646206e9ddf


We're also stricter about not accepting blank names:

https://github.com/user-attachments/assets/40563284-2460-4fa8-b674-54f1c18c121b

Followup work: the "names must be non-empty" check is only enforced in the UI at creation time. Notably missing are:
1. a migration for existing "invalid" data
2. requiring names for projects loaded from JSON.

I don't anticipate that either of these would be especially hard, but it seemed lower priority, given that we don't actually rely on the names being non-empty as far as I know.