### PR TITLE
CI runs ts type checking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,6 @@ jobs:
           cd web
           npm ci
           npm run wasm
-          # typechecking requires the wasm build
-          npm run check
           npm test
+          # typechecking requires the wasm build and for vite to see the build
+          npm run check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,20 +39,18 @@ jobs:
 
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
-      
+
       - name: Cache WASM build
         uses: actions/cache@v3
         with:
           path: target
           key: cargo-wasm-test-${{ hashFiles('Cargo.lock') }}
 
-      - name: Build wasm
+      - name: Build and test
         run: |
           cd web
           npm ci
           npm run wasm
-
-      - name: Run web tests
-        run: |
-          cd web
+          # typechecking requires the wasm build
+          npm run check
           npm test


### PR DESCRIPTION
My typescript editor (usually vscode) doesn't inspect files unless they're in an open tab, so I sometimes don't see type errors for a while. 

e.g I originally opened #270 with a [type error](https://github.com/a-b-street/ltn/compare/de7396eb277963afa16e2534d8ab94d0370da70c..67b748f312d337cc746d801162a59484b59bd159) (In this case, it wasn't a real error, just something too confusing for typescript). 