### PR TITLE
Fix occasionally missing hover state.

### DIFF
--- a/web/src/CntChooseArea.svelte
+++ b/web/src/CntChooseArea.svelte
@@ -112,6 +112,6 @@
       "line-width": 2.5,
     }}
     beforeId="Road labels"
-    manageHoverState
+    manageHoverState={false}
   />
 </GeoJSON>


### PR DESCRIPTION
There seems to be a bug in svelte-maplibre (or maplibre?). Presumably the issue is related to quickly switching between hovered features.

To reproduce pan into and out of one of the CNT boundaries. About 10% of the time, the background will not be colored appropriately for the hover state. Interestingly, the popup will still appear.

https://github.com/user-attachments/assets/5d4d9f0f-6a60-4537-af16-f698343f2d43

I cannot reproduce the issue after removing "hover" handling from the linestring borders. We don't need it anyway.

There is a similar seeming bug in the autgen boundaries page where occasionally, an empty popup appears. It seems slightly less reproducible, but still fairly common to see. I haven't figured that one out yet, but stay vigilant 👀.

Here's what that (unresolved issue) looks like:

https://github.com/user-attachments/assets/45696952-ef2a-40f6-a2fa-eb4b6fb7c737


 
