### PR TITLE
Include schema version in savefile

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -63,6 +63,7 @@ impl LTN {
         app_focus: String,
         study_area_name: Option<String>,
         project_name: String,
+        db_schema_version: u32,
     ) -> Result<LTN, JsValue> {
         // Panics shouldn't happen, but if they do, console.log them.
         console_error_panic_hook::set_once();
@@ -95,6 +96,7 @@ impl LTN {
             app_focus,
             study_area_name,
             project_name,
+            db_schema_version,
         };
         let map = MapModel::new(
             input_bytes,

--- a/backend/src/map_model.rs
+++ b/backend/src/map_model.rs
@@ -224,6 +224,7 @@ pub struct ProjectDetails {
     pub app_focus: String,
     pub study_area_name: Option<String>,
     pub project_name: String,
+    pub db_schema_version: u32,
 }
 
 impl MapModel {

--- a/backend/src/osm_tests/mod.rs
+++ b/backend/src/osm_tests/mod.rs
@@ -1,4 +1,5 @@
 use crate::map_model::ProjectDetails;
+use crate::test_fixtures::TEST_DB_SCHEMA_VERSION;
 use crate::MapModel;
 use geo::MultiPolygon;
 
@@ -41,6 +42,7 @@ pub fn load_osm_xml(filename: &str) -> MapModel {
         project_name: "test-project".to_string(),
         study_area_name: None,
         app_focus: "global".to_string(),
+        db_schema_version: TEST_DB_SCHEMA_VERSION,
     };
     MapModel::new(
         &std::fs::read(path).unwrap(),

--- a/backend/src/test_fixtures.rs
+++ b/backend/src/test_fixtures.rs
@@ -47,6 +47,11 @@ impl NeighbourhoodFixture {
     };
 }
 
+// Currently, `db_schema_version` is only used by the frontend for import/export.
+// To the backend it's opaque, so the value here currently has no consequence.
+// In theory, we could one day do our schema migrations in rust.
+pub const TEST_DB_SCHEMA_VERSION: u32 = 3;
+
 impl NeighbourhoodFixture {
     pub fn map_model(&self) -> Result<MapModel> {
         self.map_model_builder()?()
@@ -135,6 +140,7 @@ impl NeighbourhoodFixture {
                 project_name: self.savefile_name.to_string(),
                 study_area_name: Some(study_area_name.to_string()),
                 app_focus: "global".to_string(),
+                db_schema_version: TEST_DB_SCHEMA_VERSION,
             };
             MapModel::new(
                 &input_bytes,

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -282,9 +282,6 @@
   :global(.pico .icon-btn),
   :global(.icon-btn) {
     margin: 0;
-    height: 36px;
-    width: 36px;
-    aspect-ratio: 1;
     padding: 6px;
     display: flex;
     align-items: center;
@@ -303,8 +300,9 @@
 
   :global(.pico .icon-btn svg),
   :global(.icon-btn svg) {
-    width: 100%;
-    height: 100%;
+    height: 22px;
+    width: 22px;
+    aspect-ratio: 1;
     object-fit: contain;
   }
 

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -273,14 +273,14 @@
     width: 65%;
   }
 
-  :global(.pico .icon-btn.destructive),
-  :global(.icon-btn.destructive),
+  :global(.pico button.icon-btn.destructive),
+  :global(button.icon-btn.destructive),
   :global(.pico button.destructive) {
     background-color: #dc2626;
   }
 
-  :global(.pico .icon-btn),
-  :global(.icon-btn) {
+  :global(.pico button.icon-btn),
+  :global(button.icon-btn) {
     margin: 0;
     padding: 6px;
     display: flex;
@@ -288,18 +288,19 @@
     justify-content: center;
   }
 
-  :global(.pico .icon-btn):hover,
-  :global(.icon-btn):hover {
+  :global(.pico button.icon-btn):hover,
+  :global(button.icon-btn):hover {
     background-color: #ddd;
   }
 
-  :global(.pico .icon-btn.destructive):hover,
-  :global(.icon-btn.destructive):hover {
+  :global(.pico button.icon-btn.destructive):hover,
+  :global(button.icon-btn.destructive):hover {
     background-color: #891717;
   }
 
-  :global(.pico .icon-btn svg),
-  :global(.icon-btn svg) {
+  :global(.pico button.icon-btn svg),
+  :global(button.icon-btn svg) {
+    flex-shrink: 0; /* Prevents the button from shrinking */
     height: 22px;
     width: 22px;
     aspect-ratio: 1;

--- a/web/src/PickNeighbourhoodMode.svelte
+++ b/web/src/PickNeighbourhoodMode.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { FeatureCollection } from "geojson";
-  import { CirclePlus, Pencil, Trash2 } from "lucide-svelte";
+  import { CirclePlus, FileDown, Pencil, Trash2 } from "lucide-svelte";
   import { type DataDrivenPropertyValueSpecification } from "maplibre-gl";
   import {
     FillLayer,
@@ -12,7 +12,7 @@
   import { downloadGeneratedFile, notNull } from "svelte-utils";
   import { Popup } from "svelte-utils/map";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
-  import { HelpButton, layerId, Link, Style } from "./common";
+  import { downloadProject, HelpButton, layerId, Link, Style } from "./common";
   import { pickNeighbourhoodName } from "./common/pick_names";
   import { ModalFilterLayer } from "./layers";
   import {
@@ -69,14 +69,6 @@
       saveCurrentProject();
       neighbourhoods = $backend!.getAllNeighbourhoods();
     }
-  }
-
-  function exportGJ() {
-    let projectID = $currentProjectID!;
-    let project = $projectStorage.project(projectID);
-    let dateFormatted = new Date().toISOString().split("T")[0];
-    let filename = `${project.project_name}-${dateFormatted}.geojson`;
-    downloadGeneratedFile(filename, JSON.stringify(project));
   }
 
   function debugRouteSnapper() {
@@ -197,7 +189,27 @@
   </div>
 
   <div slot="sidebar">
-    <h1>{$projectStorage.projectName(notNull($currentProjectID))}</h1>
+    <div
+      style="display: flex; justify-content: space-between; align-items: center; gap: 16px;"
+    >
+      <h1>{$projectStorage.projectName(notNull($currentProjectID))}</h1>
+      <button
+        class="outline icon-btn"
+        style="margin-right: 8px;"
+        title="Download project as GeoJSON"
+        on:click={() => downloadProject(notNull($currentProjectID))}
+      >
+        <div style="display: flex; align-items: center; gap: 8px;">
+          <FileDown color="black" />
+          <!-- 
+            The text feels a little crowded aginst the right edge. 
+            Currently this is the only place we use an icon+text button like this.
+            But if we do more, we might want to pattern something out.
+          -->
+          <span style="margin-right: 2px;">Export</span>
+        </div>
+      </button>
+    </div>
     <h2>Neighbourhoods</h2>
     <ul class="navigable-list">
       {#each neighbourhoods.features as { properties: { name } }}
@@ -212,14 +224,14 @@
           <span class="actions">
             <button
               class="outline icon-btn"
-              aria-label="Rename neighbourhood"
+              title="Rename neighbourhood"
               on:click={() => renameNeighbourhood(name)}
             >
               <Pencil color="black" />
             </button>
             <button
               class="icon-btn destructive"
-              aria-label="Delete neighbourhood"
+              title="Delete neighbourhood"
               on:click={() => deleteNeighbourhood(name)}
             >
               <Trash2 color="white" />
@@ -251,7 +263,6 @@
     </p>
     <p>{edits.travelFlows} road segment direction(s) changed</p>
 
-    <button on:click={exportGJ}>Export project to GeoJSON</button>
     {#if $devMode}
       <button class="secondary" on:click={debugRouteSnapper}>
         Debug route-snapper

--- a/web/src/common/HelpButton.svelte
+++ b/web/src/common/HelpButton.svelte
@@ -10,7 +10,7 @@
 
 <button
   class="icon-btn help"
-  aria-label="Help"
+  title="Help"
   on:click|stopPropagation={() => (show = true)}
 >
   <CircleHelp {color} />

--- a/web/src/common/index.ts
+++ b/web/src/common/index.ts
@@ -2,9 +2,10 @@ import type {
   DataDrivenPropertyValueSpecification,
   ExpressionSpecification,
 } from "maplibre-gl";
+import { downloadGeneratedFile } from "svelte-utils";
 import { get } from "svelte/store";
-import { appFocus } from "../stores";
-import { type StudyAreaName } from "./ProjectStorage";
+import { appFocus, projectStorage } from "../stores";
+import { type ProjectID, type StudyAreaName } from "./ProjectStorage";
 
 export { default as BasemapPicker } from "./BasemapPicker.svelte";
 export { default as ContextLayerButton } from "./ContextLayerButton.svelte";
@@ -79,6 +80,13 @@ export function prettyPrintStudyAreaName(studyAreaName: StudyAreaName): string {
   } else {
     return studyAreaName;
   }
+}
+
+export function downloadProject(projectID: ProjectID) {
+  let project = get(projectStorage).project(projectID);
+  let dateFormatted = new Date().toISOString().split("T")[0];
+  let filename = `${project.project_name}-${dateFormatted}.geojson`;
+  downloadGeneratedFile(filename, JSON.stringify(project));
 }
 
 /**

--- a/web/src/title/LoadSavedProject.svelte
+++ b/web/src/title/LoadSavedProject.svelte
@@ -52,7 +52,6 @@
         projectName = stripSuffix(stripPrefix(filename, "ltn_"), ".geojson");
       }
     }
-
     // Verified non-null by the above if statement
     projectName = projectName!;
     appFocus = appFocus!;

--- a/web/src/title/NewProjectMode.svelte
+++ b/web/src/title/NewProjectMode.svelte
@@ -42,6 +42,7 @@
         $appFocus,
         studyAreaName,
         newProjectName,
+        $projectStorage.dbSchemaVersion,
       );
 
       const projectID = $projectStorage.createProject($backend.toSavefile());

--- a/web/src/title/TitleMode.svelte
+++ b/web/src/title/TitleMode.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { Pencil, Trash2 } from "lucide-svelte";
+  import { FileDown, Pencil, Trash2 } from "lucide-svelte";
   import { Loading } from "svelte-utils";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
   import CntChooseArea from "../CntChooseArea.svelte";
-  import { Link, prettyPrintStudyAreaName } from "../common";
+  import { downloadProject, Link, prettyPrintStudyAreaName } from "../common";
   import { routeTool } from "../common/draw_area/stores";
   import { type ProjectID } from "../common/ProjectStorage";
   import {
@@ -128,14 +128,21 @@
                   <span class="actions">
                     <button
                       class="outline icon-btn"
-                      aria-label="Rename project"
+                      title="Download project as GeoJSON"
+                      on:click={() => downloadProject(projectID)}
+                    >
+                      <FileDown color="black" />
+                    </button>
+                    <button
+                      class="outline icon-btn"
+                      title="Rename project"
                       on:click={() => renameProject(projectID, projectName)}
                     >
                       <Pencil color="black" />
                     </button>
                     <button
                       class="icon-btn destructive"
-                      aria-label="Delete project"
+                      title="Delete project"
                       on:click={() => deleteProject(projectID, projectName)}
                     >
                       <Trash2 color="white" />

--- a/web/src/title/loader.ts
+++ b/web/src/title/loader.ts
@@ -38,6 +38,7 @@ export async function loadProject(projectID: ProjectID) {
         project.app_focus,
         project.study_area_name,
         project.project_name,
+        project.db_schema_version,
       ),
     );
     // TODO Rename savefile -> project? Or combine this call with the constructor?

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -63,6 +63,7 @@ export class Backend {
     appFocus: AppFocus,
     studyAreaName: StudyAreaName,
     projectName: string,
+    dbSchemaVersion: number,
   ) {
     this.inner = new LTN(
       osmInput,
@@ -72,6 +73,7 @@ export class Backend {
       appFocus,
       studyAreaName,
       projectName,
+      dbSchemaVersion,
     );
   }
 


### PR DESCRIPTION
FIXES #138 

Also, some related UI work:

Added a "quick" (redundant) download button on the project picker table:
<img width="641" alt="Screenshot 2025-03-27 at 12 39 29" src="https://github.com/user-attachments/assets/197edffd-775a-4dfd-ba72-a0bf46f6e46f" />

---

And with the pre-existing export project button:

**before:** export project button at the bottom of the project details.
<img width="532" alt="Screenshot 2025-03-27 at 12 39 18" src="https://github.com/user-attachments/assets/4d0e6f00-53b8-4449-9ad2-8ec93dc43391" />

**after:** export project button at the top, in line with the project name.
<img width="528" alt="Screenshot 2025-03-27 at 12 38 48" src="https://github.com/user-attachments/assets/e58c37cd-57eb-43d5-9414-98c1745f9e34" />

I'm not entirely clear about this change. 
It's a little more economical from a vertical space perspective (which is a hot commodity in our UI!)
I think it better mirrors the new "quick" download button. Conceivably we could mirror the other actions here too, in particular "rename project", but maybe also "delete project".
