### PR TITLE
Temporarily fade the border arrows to mitigate #279.

### DIFF
--- a/web/src/layers/CellLayer.svelte
+++ b/web/src/layers/CellLayer.svelte
@@ -22,6 +22,7 @@
   filter={["==", ["get", "kind"], "border_arrow"]}
   paint={{
     "fill-color": ["get", "color"],
+    "fill-opacity": 0.7,
   }}
   minzoom={14}
 />


### PR DESCRIPTION
@XioNoX just proposed slightly fading the border arrows to be able to see underneath them in #287. I tried this, and think it still looks legible but now lets you see grey / not-grey roads underneath:
![image](https://github.com/user-attachments/assets/3ddbd652-04e5-437e-a0d1-39ef93214e81)
Before the full approach in #279, how about we do this as a workaround. I'll ASAP merge this to unblock users having this problem, and we can adjust easily later.