### PR TITLE
FIX: adding diagonal filter also adds modal filter

### DIFF
--- a/web/src/layers/NeighbourhoodRoadLayer.svelte
+++ b/web/src/layers/NeighbourhoodRoadLayer.svelte
@@ -102,7 +102,7 @@
 />
 
 <LineLayer
-  {...layerId("interior-roads", false)}
+  {...layerId("interior-roads")}
   filter={["==", ["get", "kind"], "interior_road"]}
   paint={{
     "line-width": lineWidth($thickRoadsForShortcuts, gj.maxShortcuts, 0),
@@ -134,7 +134,7 @@
 />
 
 <LineLayer
-  {...layerId("main-roads", false)}
+  {...layerId("main-roads")}
   filter={["==", ["get", "kind"], "main_road"]}
   paint={{
     "line-width": lineWidth($thickRoadsForShortcuts, gj.maxShortcuts, 4),


### PR DESCRIPTION
FIXES #290 

This is a partial revert of https://github.com/a-b-street/ltn/commit/49629fec0a0d543a69929b9cd64e5ba5115eb464#diff-eb72a5e7f5a0b04e27ba1e11c412351855e54f41c1ca662fb0556dc652d818a5R100

Which introduced manually marking/unmarking a road as a "main road".

@dabreegster - do you recall why adding this option was necessary. In my testing I'm still able to mark/unmark roads without this option. If we need it, I'll have to come up with another way to resolve the issue.



