### PR TITLE
move road thickness "setting" to neighourhood -> "map style"

### DIFF
--- a/web/src/Settings.svelte
+++ b/web/src/Settings.svelte
@@ -2,7 +2,7 @@
   import { Modal } from "svelte-utils";
   import icon from "../assets/settings.svg?url";
   import { BasemapPicker } from "./common";
-  import { devMode, thickRoadsForShortcuts } from "./stores";
+  import { devMode } from "./stores";
 
   let show = false;
 </script>
@@ -15,11 +15,6 @@
   <h1>Settings</h1>
 
   <BasemapPicker />
-
-  <label>
-    <input type="checkbox" bind:checked={$thickRoadsForShortcuts} />
-    Road thickness depends on shortcuts
-  </label>
 
   <label>
     <input type="checkbox" bind:checked={$devMode} />

--- a/web/src/edit/NeighbourhoodMode.svelte
+++ b/web/src/edit/NeighbourhoodMode.svelte
@@ -48,6 +48,7 @@
     returnToChooseProject,
     roadStyle,
     saveCurrentProject,
+    thickRoadsForShortcuts,
   } from "../stores";
   import type {
     NeighbourhoodBoundaryFeature,
@@ -561,42 +562,52 @@
     </div>
 
     <h2>Map style</h2>
-
     <label>
       <input type="checkbox" bind:checked={$animateShortcuts} />
-      Animate shortcuts
+      Animate shortcuts<sup>[1]</sup>
     </label>
+
+    <label>
+      <input type="checkbox" bind:checked={$drawBorderEntries} />
+      Show entries into cells<sup>[2]</sup>
+    </label>
+
+    <label>
+      <input type="checkbox" bind:checked={$thickRoadsForShortcuts} />
+      Road thickness depends on shortcuts<sup>[1]</sup>
+    </label>
+
+    <label style="display: flex; align-items: center; gap: 8px;">
+      <span style="text-wrap: nowrap;">Draw roads:</span>
+      <select
+        style="margin: 0; padding: 8px; width: auto;"
+        bind:value={$roadStyle}
+      >
+        <option value="shortcuts">Worst shortcuts</option>
+        <option value="cells">Cell</option>
+        <option value="edits">Edits (either filter or direction)</option>
+        <option value="speeds">Speed limit</option>
+      </select>
+    </label>
+    {#if $roadStyle == "speeds"}
+      <SequentialLegend
+        colorScale={speedColorScale}
+        labels={{ limits: speedLimits }}
+      />
+    {/if}
+
+    <br />
     <p>
+      <sup>[1]</sup>
       <i>Shortcuts</i>
       are routes from one main road to another, which cut through the neighborhood's
       interior.
     </p>
-
-    <label>
-      <input type="checkbox" bind:checked={$drawBorderEntries} />
-      Show arrows into cells
-    </label>
     <p>
-      <i>Cells</i> show the area reachable without travelling along a main road.
+      <sup>[2]</sup>
+      <i>Cells</i> are the colored area reachable without travelling along a main
+      road.
     </p>
-
-    <div style="border: 1px solid black; padding: 4px">
-      <label>
-        Draw roads:
-        <select bind:value={$roadStyle}>
-          <option value="shortcuts">Worst shortcuts</option>
-          <option value="cells">Cell</option>
-          <option value="edits">Edits (either filter or direction)</option>
-          <option value="speeds">Speed limit</option>
-        </select>
-      </label>
-      {#if $roadStyle == "speeds"}
-        <SequentialLegend
-          colorScale={speedColorScale}
-          labels={{ limits: speedLimits }}
-        />
-      {/if}
-    </div>
 
     <h2>Neighbourhood stats</h2>
     <NeighbourhoodBoundarySummary neighbourhoodBoundary={notNull(boundary)} />


### PR DESCRIPTION
Part of #121 

This setting only affects the map in NeighbourhoodMode anyway. It fits nicely along side options like "Animate shortcuts" and "Show entires into cells".

I also applied a "footnote" style to the Cells and Shortcut "definitions" in the Map style copy.

**before:** Road thickness depends on shortcuts was in the "global settings" menu in the title bar.

<img width="762" alt="Screenshot 2025-04-02 at 16 14 52" src="https://github.com/user-attachments/assets/0841a109-2f67-4111-897d-a7bf2cfe7dca" />

**before:** Map style within neighborhoods:
 
<img width="1624" alt="Screenshot 2025-04-02 at 16 15 01" src="https://github.com/user-attachments/assets/f97a1506-a939-44ef-b68d-c46eb523b52f" />

**After:** "Road thickness..." moved into map style

<img width="1624" alt="Screenshot 2025-04-02 at 16 14 17" src="https://github.com/user-attachments/assets/71afddba-494c-4e4c-8dca-9db566f28727" />

Also, put the "road style" control on a single line, which obviates the need for a border.

I also restyled the definitions as "footnotes", since they were a little awkward inline, and could apply to multiple settings. And tweaked the cells copy to mention "colored". WDYT?
