### PR TITLE
Move map controls to map

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -7,10 +7,14 @@
   import ContextualLayers from "./context/ContextualLayers.svelte";
   import "@picocss/pico/css/pico.conditional.jade.min.css";
   import initLtn from "backend";
+  import { House } from "lucide-svelte";
   import type { LngLatBoundsLike, Map, StyleSpecification } from "maplibre-gl";
   import { init as initRouteSnapper } from "route-snapper-ts";
   import { onMount } from "svelte";
   import {
+    Control,
+    ControlButton,
+    ControlGroup,
     FillLayer,
     GeoJSON,
     MapLibre,
@@ -79,8 +83,8 @@
     mapStore.set(map);
   }
 
-  function zoomToFit() {
-    $mapStore!.fitBounds($backend!.getBounds(), { animate: false });
+  function zoomToFit(animate: boolean) {
+    $mapStore!.fitBounds($backend!.getBounds(), { animate });
   }
 
   let topDiv: HTMLSpanElement;
@@ -138,9 +142,6 @@
       <hr />
 
       {#if $backend}
-        <button class="secondary" on:click={zoomToFit}>
-          Zoom to fit study area
-        </button>
         <StreetView
           map={notNull($mapStore)}
           maptilerBasemap={$maptilerBasemap}
@@ -216,8 +217,25 @@
           ]}
         >
           <NavigationControl />
-          <ScaleControl />
+
+          {#if $backend}
+            <Control position="top-left">
+              <ControlGroup>
+                <ControlButton
+                  title="Zoom to fit study area"
+                  on:click={() => zoomToFit(true)}
+                >
+                  <div class="zoom-to-fit-map-btn">
+                    <House />
+                  </div>
+                </ControlButton>
+              </ControlGroup>
+            </Control>
+          {/if}
+
           <Geocoder {map} apiKey={maptilerApiKey} country={undefined} />
+
+          <ScaleControl />
 
           <div bind:this={mapDiv} />
 
@@ -442,5 +460,10 @@
   }
   :global(.top .pico nav ul li) {
     padding: 8px 8px;
+  }
+
+  :global(.zoom-to-fit-map-btn svg) {
+    height: 20px;
+    width: auto;
   }
 </style>

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -138,15 +138,6 @@
     </div>
     <div class="pico" slot="left">
       <div bind:this={sidebarDiv} />
-
-      <hr />
-
-      {#if $backend}
-        <StreetView
-          map={notNull($mapStore)}
-          maptilerBasemap={$maptilerBasemap}
-        />
-      {/if}
     </div>
     <div slot="main" style="position: relative; width: 100%; height: 100%;">
       {#await getStyle($maptilerBasemap) then style}
@@ -225,10 +216,18 @@
                   title="Zoom to fit study area"
                   on:click={() => zoomToFit(true)}
                 >
-                  <div class="zoom-to-fit-map-btn">
+                  <div class="ltn-map-btn zoom-to-fit-btn">
                     <House />
                   </div>
                 </ControlButton>
+              </ControlGroup>
+            </Control>
+            <Control position="top-left">
+              <ControlGroup>
+                <StreetView
+                  map={notNull($mapStore)}
+                  maptilerBasemap={$maptilerBasemap}
+                />
               </ControlGroup>
             </Control>
           {/if}
@@ -462,8 +461,9 @@
     padding: 8px 8px;
   }
 
-  :global(.zoom-to-fit-map-btn svg) {
+  :global(.ltn-map-btn svg) {
     height: 20px;
     width: auto;
+    margin-top: 2px;
   }
 </style>

--- a/web/src/common/StreetView.svelte
+++ b/web/src/common/StreetView.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
+  import { Eye, EyeClosed } from "lucide-svelte";
   import type { Map, MapMouseEvent } from "maplibre-gl";
   import { onDestroy } from "svelte";
+  import { ControlButton } from "svelte-maplibre";
   import { getRoadLayerNames } from "./highlight_roads";
   import { interactiveMapLayersEnabled } from "./stores";
 
   // TODO Need to intercept the escape key always
-  // TODO Make sure all layers respect DisableInteractiveLayers
+  // TODO Make sure all layers respect DisableInteractiveLayers (they currently do not)
 
   export let map: Map;
   export let maptilerBasemap: string;
+  let expanded = false;
 
   let source: "google" | "bing" = "google";
   let defaultLineColorPerLayer: [string, any][] = [];
@@ -66,20 +69,59 @@
 
 <svelte:window on:keydown={onKeyDown} />
 
-{#if $interactiveMapLayersEnabled}
-  <button class="secondary" on:click={start}>StreetView</button>
-{:else}
-  <button class="secondary" on:click={stop}>Stop StreetView</button>
+<ControlButton>
+  <button
+    on:click={() => {
+      expanded = !expanded;
+      expanded ? start() : stop();
+    }}
+    title="Street view"
+  >
+    <div class="ltn-map-btn">
+      {#if expanded}
+        <EyeClosed />
+      {:else}
+        <Eye />
+      {/if}
+    </div>
+  </button>
+  {#if expanded}
+    <div class="street-view-control-source" class:expanded>
+      Click the map to see street view
+      <br />
+      <br />
+      <b>Street view source</b>
+      <label>
+        <input type="radio" value="google" bind:group={source} />
+        Google Street View
+      </label>
+      <label>
+        <input type="radio" value="bing" bind:group={source} />
+        Bing Streetside
+      </label>
+    </div>
+  {/if}
+</ControlButton>
 
-  <fieldset>
-    <legend>Source:</legend>
-    <label>
-      <input type="radio" value="google" bind:group={source} />
-      Google Street View
-    </label>
-    <label>
-      <input type="radio" value="bing" bind:group={source} />
-      Bing Streetside
-    </label>
-  </fieldset>
-{/if}
+<style>
+  .street-view-control-source.expanded {
+    position: absolute;
+    top: 34px;
+    width: 200px;
+    background: white;
+    border-radius: 4px;
+    padding: 10px;
+    text-align: left;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+    cursor: default;
+  }
+  .street-view-control-source label {
+    display: block;
+    text-align: left;
+    margin-top: 4px;
+    cursor: pointer;
+  }
+  .street-view-control-source input {
+    cursor: pointer;
+  }
+</style>


### PR DESCRIPTION
FIXES #121 (last item in the grab bag)

**before:** these controls were on every screen in the left panel
<img width="1624" alt="Screenshot 2025-04-03 at 17 07 58" src="https://github.com/user-attachments/assets/8c6f5826-771e-4be4-b605-b3ce53701a28" />

**after:** Now they're on the map panel, along side our other map controls

<img width="1624" alt="Screenshot 2025-04-03 at 17 06 26" src="https://github.com/user-attachments/assets/a6750a7a-bcba-4455-ad44-7a82bbf26a55" />

**flow:**

https://github.com/user-attachments/assets/e4b8376e-8ad8-450f-a1ad-7680bc1b38f1

Changing the "eye" icon when the configuration is presented is somewhat silly, but I think it helps communicate that the button has two states. Click it again to close it and return to the default state.