### PR TITLE
Layer control: small design improvements

### DIFF
--- a/web/src/common/ContextLayerButton.svelte
+++ b/web/src/common/ContextLayerButton.svelte
@@ -6,14 +6,14 @@
 </script>
 
 <button
+  class="context-control"
   style="display: flex; align-items: center; justify-content: leading; gap: 8px; text-align: left;"
-  class="secondary"
   on:click={() => (show = !show)}
 >
   <input style="aspect-ratio: 1.0" type="checkbox" bind:checked={show} />
   {label}
   {#if $$slots.help}
-    <HelpButton color="var(--pico-secondary-inverse)">
+    <HelpButton color="white">
       <div class="context-layer-help-content">
         <slot name="help" />
       </div>
@@ -35,7 +35,8 @@
     padding-left: 4px;
   }
   .legend {
-    padding: 8px;
     background-color: white;
+    color: black;
+    padding: 8px;
   }
 </style>

--- a/web/src/common/ContextLayerButton.svelte
+++ b/web/src/common/ContextLayerButton.svelte
@@ -13,7 +13,7 @@
   <input style="aspect-ratio: 1.0" type="checkbox" bind:checked={show} />
   {label}
   {#if $$slots.help}
-    <HelpButton color="white">
+    <HelpButton>
       <div class="context-layer-help-content">
         <slot name="help" />
       </div>
@@ -35,7 +35,6 @@
     padding-left: 4px;
   }
   .legend {
-    background-color: white;
     color: black;
     padding: 8px;
   }

--- a/web/src/context/ContextualLayers.svelte
+++ b/web/src/context/ContextualLayers.svelte
@@ -60,30 +60,29 @@
           <Stats19 />
         {/if}
       {/if}
-      <span
-        style="font-size: 20px; color: var(--pico-secondary-inverse); margin-left: 8px; margin-top: 4px;"
-      >
-        Basemap
-      </span>
-      <select
-        style="width: auto; font-size: 20px; margin: 8px; padding: 8px; text-overflow: ellipsis;"
-        bind:value={$maptilerBasemap}
-      >
-        <option value="dataviz">MapTiler Dataviz</option>
-        <option value="streets-v2">MapTiler Streets</option>
-        <option value="hybrid">MapTiler Satellite</option>
-        <option value="uk-openzoomstack-light">OS Open Zoomstack</option>
-      </select>
+      <div class="context-control">
+        <span style="font-size: 20px; margin-left: 8px; margin-top: 4px;">
+          Basemap
+        </span>
+        <select
+          style="width: auto; font-size: 20px; margin: 8px; padding: 8px; text-overflow: ellipsis;"
+          bind:value={$maptilerBasemap}
+        >
+          <option value="dataviz">MapTiler Dataviz</option>
+          <option value="streets-v2">MapTiler Streets</option>
+          <option value="hybrid">MapTiler Satellite</option>
+          <option value="uk-openzoomstack-light">OS Open Zoomstack</option>
+        </select>
+      </div>
     </div>
   </div>
 </Control>
 
 <style>
   .contextual-layers {
-    background: #515F7A;
+    background: white;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
     border-radius: 5px;
-    color: white;
   }
   button.show-layers-button {
     background-color: #fff;
@@ -110,8 +109,12 @@
   :global(.pico.contextual-layers .context-control) {
     border: none;
     border-radius: 0;
-    color: white;
+    color: black;
     background: none;
     padding: 8px 8px;
+  }
+
+  :global(.pico.contextual-layers .context-control:not(:first-child)) {
+    border-top: solid #ddd 1px;
   }
 </style>

--- a/web/src/context/ContextualLayers.svelte
+++ b/web/src/context/ContextualLayers.svelte
@@ -19,10 +19,10 @@
   let expand = false;
 </script>
 
-<Control defaultStyling={true}>
+<Control defaultStyling>
   <div
     class="pico contextual-layers"
-    style="display: flex; flex-direction: column; max-height: 80vh; overflow: auto; border-radius: 5px;"
+    style="display: flex; flex-direction: column; border-radius: 5px;"
     style:width={expand ? "300px" : "auto"}
   >
     <button
@@ -41,9 +41,9 @@
     </button>
 
     <div
-      style="flex-direction: column"
+      class="contextual-layer-controls"
+      style="flex-direction: column;"
       style:display={expand ? "flex" : "none"}
-      style:background-color="#515f7A"
     >
       {#if $backend}
         <ContextLayerButton
@@ -79,21 +79,39 @@
 </Control>
 
 <style>
-  .pico button.show-layers-button {
+  .contextual-layers {
+    background: #515F7A;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+    border-radius: 5px;
+    color: white;
+  }
+  button.show-layers-button {
     background-color: #fff;
+    border-radius: 5px;
     border-color: #999;
     width: 44px;
     height: 44px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
   }
-  .pico button.show-layers-button.expanded {
+  button.show-layers-button:hover {
+    background-color: #eee;
+  }
+  button.show-layers-button.expanded {
     width: 100%;
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-  .pico button.show-layers-button:hover {
     background-color: #f2f2f2;
+    border-bottom: none;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
   }
-  :global(.pico.contextual-layers button) {
+  .contextual-layer-controls {
+    max-height: calc(100vh - 160px);
+    overflow: auto;
+  }
+  :global(.pico.contextual-layers .context-control) {
+    border: none;
+    border-radius: 0;
+    color: white;
+    background: none;
     padding: 8px 8px;
   }
 </style>


### PR DESCRIPTION
FIXES #276 

**Before:** Scrolling down would scroll the header out of view, so it was harder to minimize the layer controls

<img width="1624" alt="Screenshot 2025-04-03 at 18 29 00" src="https://github.com/user-attachments/assets/925b3f77-6853-4726-a67f-4c5a2a84ff8a" />

**After:** Content scrolls behind the header, so you can always minimize the layers
<img width="1580" alt="Screenshot 2025-04-03 at 18 35 51" src="https://github.com/user-attachments/assets/7b6d2bd9-6521-4b06-b775-0af23459a09e" />

I also changed the color scheme to be more neutral - the previous colors were based on the "pico secondary" button styles which feel very heavy to me. 

<img width="1624" alt="Screenshot 2025-04-03 at 18 35 46" src="https://github.com/user-attachments/assets/7abd454d-c965-4b01-9c05-56ad0760ccc4" />

I don't feel super strongly about that part of the change though. I put it into a separate commit so you could easily revert it if you prefer something closer to the old colors.
