### PR TITLE
better breadcrumbs

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -244,6 +244,8 @@ impl LTN {
         self.neighbourhood =
             Some(Neighbourhood::new(&self.map, boundary.clone()).map_err(err_to_js)?);
 
+        debug_assert!(!editing_same, "I don't think this happens anymore since we got rid of 'edit_perimeter_roads'");
+
         // Undoing edits in another neighbourhood doesn't make sense
         if !editing_same {
             self.map.undo_stack.clear();

--- a/web/src/AddNeighbourhoodMode.svelte
+++ b/web/src/AddNeighbourhoodMode.svelte
@@ -27,6 +27,7 @@
   import {
     appFocus,
     backend,
+    currentNeighbourhoodName,
     currentProjectID,
     map,
     mode,
@@ -161,6 +162,7 @@
       $backend!.setNeighbourhoodBoundary(name, feature);
       saveCurrentProject();
       $backend!.setCurrentNeighbourhood(name);
+      $currentNeighbourhoodName = name;
       $mode = {
         mode: "neighbourhood",
       };

--- a/web/src/AddNeighbourhoodMode.svelte
+++ b/web/src/AddNeighbourhoodMode.svelte
@@ -159,10 +159,9 @@
         properties,
         geometry: selectedBoundary.geometry,
       };
-      $backend!.setNeighbourhoodBoundary(name, feature);
-      saveCurrentProject();
-      $backend!.setCurrentNeighbourhood(name);
+      $backend!.setCurrentNeighbourhoodBoundary(name, feature);
       $currentNeighbourhoodName = name;
+      saveCurrentProject();
       $mode = {
         mode: "neighbourhood",
       };

--- a/web/src/PickNeighbourhoodMode.svelte
+++ b/web/src/PickNeighbourhoodMode.svelte
@@ -35,7 +35,6 @@
     currentProjectID,
     devMode,
     mode,
-    projectStorage,
     saveCurrentProject,
   } from "./stores";
   import type { NeighbourhoodBoundaryFeature } from "./wasm";
@@ -195,7 +194,7 @@
     <div
       style="display: flex; justify-content: space-between; align-items: center; gap: 16px;"
     >
-      <h1>{$projectStorage.projectName(notNull($currentProjectID))}</h1>
+      <h2>Neighbourhoods</h2>
       <button
         class="outline icon-btn"
         style="margin-right: 8px;"
@@ -215,7 +214,6 @@
         </div>
       </button>
     </div>
-    <h2>Neighbourhoods</h2>
     <ul class="navigable-list">
       {#each neighbourhoods.features as { properties: { name } }}
         <li

--- a/web/src/PickNeighbourhoodMode.svelte
+++ b/web/src/PickNeighbourhoodMode.svelte
@@ -31,6 +31,7 @@
   import {
     appFocus,
     backend,
+    currentNeighbourhoodName,
     currentProjectID,
     devMode,
     mode,
@@ -46,9 +47,11 @@
   let selectedPrioritization: Prioritization = "none";
   let hoveredNeighbourhoodFromList: string | null = null;
   let hoveredMapFeature: NeighbourhoodBoundaryFeature | null = null;
+  $currentNeighbourhoodName = undefined;
 
   function pickNeighbourhood(name: string) {
     $backend!.setCurrentNeighbourhood(name);
+    $currentNeighbourhoodName = name;
     $mode = { mode: "neighbourhood" };
   }
 
@@ -59,6 +62,7 @@
       )
     ) {
       $backend!.deleteNeighbourhoodBoundary(name);
+      console.assert(!currentNeighbourhoodName);
       saveCurrentProject();
       // TODO Improve perf, don't call this twice
       neighbourhoods = $backend!.getAllNeighbourhoods();
@@ -73,6 +77,7 @@
     );
     if (newName) {
       $backend!.renameNeighbourhoodBoundary(name, newName);
+      $currentNeighbourhoodName = newName;
       saveCurrentProject();
       neighbourhoods = $backend!.getAllNeighbourhoods();
     }

--- a/web/src/SetBoundaryMode.svelte
+++ b/web/src/SetBoundaryMode.svelte
@@ -7,7 +7,7 @@
   import { gjPosition, ModeLink, pageTitle } from "./common";
   import AreaControls from "./common/draw_area/AreaControls.svelte";
   import { type Waypoint } from "./common/draw_area/stores";
-  import { backend, map, mode, saveCurrentProject } from "./stores";
+  import { backend, currentNeighbourhoodName, map, mode, saveCurrentProject } from "./stores";
 
   export let name: string;
   export let existing: Feature<Polygon, AreaProps>;
@@ -39,10 +39,9 @@
       try {
         $backend!.setNeighbourhoodBoundary(name, drawnShape);
         saveCurrentProject();
+        console.assert(name == $currentNeighbourhoodName);
         $backend!.setCurrentNeighbourhood(name);
-        $mode = {
-          mode: "neighbourhood",
-        };
+        $mode = { mode: "neighbourhood" };
       } catch (err) {
         window.alert(`Sorry, this boundary is invalid: ${err}`);
         cancel();

--- a/web/src/SetBoundaryMode.svelte
+++ b/web/src/SetBoundaryMode.svelte
@@ -7,7 +7,7 @@
   import { gjPosition, ModeLink, pageTitle } from "./common";
   import AreaControls from "./common/draw_area/AreaControls.svelte";
   import { type Waypoint } from "./common/draw_area/stores";
-  import { backend, currentNeighbourhoodName, map, mode, saveCurrentProject } from "./stores";
+  import { backend, map, mode, saveCurrentProject } from "./stores";
 
   export let name: string;
   export let existing: Feature<Polygon, AreaProps>;
@@ -37,10 +37,8 @@
   function finish() {
     if (drawnShape) {
       try {
-        $backend!.setNeighbourhoodBoundary(name, drawnShape);
+        $backend!.setCurrentNeighbourhoodBoundary(name, drawnShape);
         saveCurrentProject();
-        console.assert(name == $currentNeighbourhoodName);
-        $backend!.setCurrentNeighbourhood(name);
         $mode = { mode: "neighbourhood" };
       } catch (err) {
         window.alert(`Sorry, this boundary is invalid: ${err}`);

--- a/web/src/common/ModeLink.svelte
+++ b/web/src/common/ModeLink.svelte
@@ -14,6 +14,18 @@
     afterLink && afterLink();
   }}
   ><slot>
-    {pageTitle(mode.mode)}
+    <span class="page-title">{pageTitle(mode.mode)}</span>
   </slot>
 </Link>
+
+<style>
+  .page-title {
+    display: inline-block;
+    max-width: 20vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin: 0;
+    vertical-align: middle;
+  }
+</style>

--- a/web/src/common/ProjectStorage.test.ts
+++ b/web/src/common/ProjectStorage.test.ts
@@ -286,7 +286,7 @@ describe("ProjectStorage", () => {
         "TestArea",
       );
       expect(projectStorage.nextAvailableNeighbourhoodName(projectID)).toBe(
-        "Test Project LTN",
+        "My neighbourhood",
       );
     });
 
@@ -301,14 +301,14 @@ describe("ProjectStorage", () => {
         geometry: { type: "Polygon", coordinates: [] },
         properties: {
           kind: "boundary",
-          name: "Test Project LTN",
+          name: "My neighbourhood",
         },
       };
       let project = projectStorage.project(projectID);
       project.features.push(existingNeighbourhood);
       projectStorage.saveProject(projectID, project);
       expect(projectStorage.nextAvailableNeighbourhoodName(projectID)).toBe(
-        "Test Project LTN #2",
+        "My neighbourhood #2",
       );
     });
 
@@ -331,7 +331,7 @@ describe("ProjectStorage", () => {
       project.features.push(existingNeighbourhood);
       projectStorage.saveProject(projectID, project);
       expect(projectStorage.nextAvailableNeighbourhoodName(projectID)).toBe(
-        "Test Project LTN",
+        "My neighbourhood",
       );
     });
   });

--- a/web/src/common/ProjectStorage.ts
+++ b/web/src/common/ProjectStorage.ts
@@ -234,9 +234,9 @@ export class ProjectStorage {
   }
 
   nextAvailableNeighbourhoodName(projectID: ProjectID): string {
-    let project = this.project(projectID);
-    let basename = `${project.project_name} LTN`;
+    let basename = "My neighbourhood";
 
+    let project = this.project(projectID);
     let neighbourhoods = project.features.filter(
       (f) => f.properties?.kind == "boundary",
     ) as Array<NeighbourhoodDefinitionFeature>;

--- a/web/src/common/navbar.ts
+++ b/web/src/common/navbar.ts
@@ -1,4 +1,5 @@
-import type { Mode } from "../stores";
+import { get } from "svelte/store";
+import { currentNeighbourhoodName, currentProject, type Mode } from "../stores";
 
 export function pageTitle(mode: Mode["mode"]): string {
   switch (mode) {
@@ -7,13 +8,13 @@ export function pageTitle(mode: Mode["mode"]): string {
     case "new-project":
       return "New project";
     case "pick-neighbourhood":
-      return "Pick neighbourhood";
+      return get(currentProject)?.project_name || "Pick neighbourhood"; // TODO truncate if necessary
     case "set-boundary":
       return "Adjust boundary";
     case "add-neighbourhood":
       return "Add a neighbourhood";
     case "neighbourhood":
-      return "Editing";
+      return get(currentNeighbourhoodName) || "Editing"; // TODO truncate if necessary
     case "view-shortcuts":
       return "View shortcuts";
     case "impact-one-destination":

--- a/web/src/edit/NeighbourhoodMode.svelte
+++ b/web/src/edit/NeighbourhoodMode.svelte
@@ -344,15 +344,6 @@
     </nav>
   </div>
   <div slot="sidebar">
-    <h1>{notNull(boundary).properties.name}</h1>
-
-    {#if numDisconnectedCells > 0}
-      <mark>
-        Some parts of the neighbourhood aren't reachable by drivers, shown in
-        red
-      </mark>
-    {/if}
-
     <h2>Editing tools</h2>
     <div
       class="tool-palette"
@@ -549,6 +540,13 @@
         </div>
       {/if}
     </div>
+
+    {#if numDisconnectedCells > 0}
+      <mark>
+        Some parts of the neighbourhood aren't reachable by drivers, shown in
+        red
+      </mark>
+    {/if}
 
     <h2>Map style</h2>
     <label>

--- a/web/src/stores.ts
+++ b/web/src/stores.ts
@@ -1,10 +1,17 @@
 import type { Feature, Polygon } from "geojson";
 import { LngLat, LngLatBounds, type Map } from "maplibre-gl";
 import { type AreaProps } from "route-snapper-ts";
-import { get, writable, type Writable } from "svelte/store";
+import {
+  derived,
+  get,
+  writable,
+  type Readable,
+  type Writable,
+} from "svelte/store";
 import {
   Database,
   ProjectStorage,
+  type ProjectFeatureCollection,
   type ProjectID,
 } from "./common/ProjectStorage";
 import type { Backend } from "./wasm";
@@ -71,14 +78,23 @@ export let appFocus: Writable<AppFocus> = writable("global");
 // The id of the project currently being worked on
 export let currentProjectID: Writable<ProjectID | undefined> =
   writable(undefined);
+export let currentProject: Readable<ProjectFeatureCollection | undefined> =
+  derived(currentProjectID, ($id) => {
+    if ($id) {
+      return get(projectStorage).project($id);
+    } else {
+      return undefined;
+    }
+  });
+
+export let currentNeighbourhoodName: Writable<string | undefined> =
+  writable(undefined);
 
 export let database = new Database();
-export let projectStorage: Writable<ProjectStorage> = writable(
-  database.projectStorage(get(appFocus)),
+export let projectStorage: Readable<ProjectStorage> = derived(
+  appFocus,
+  ($appFocus) => database.projectStorage($appFocus),
 );
-appFocus.subscribe((focus) => {
-  projectStorage.set(database.projectStorage(focus));
-});
 
 export let firstTimeLoadProjectFromURL = writable(true);
 

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -150,8 +150,8 @@ export class Backend {
     return JSON.parse(serializedMergedBoundary);
   }
 
-  setNeighbourhoodBoundary(name: string, input: Feature) {
-    this.inner.setNeighbourhoodBoundary(name, input);
+  setCurrentNeighbourhoodBoundary(name: string, input: Feature) {
+    this.inner.setCurrentNeighbourhoodBoundary(name, input);
   }
 
   deleteNeighbourhoodBoundary(name: string) {


### PR DESCRIPTION
FIXES #280 

Based on #312, so review that first.

https://github.com/user-attachments/assets/e0ebef46-e055-4a4d-9a79-9ab104c3f8bc

(🤦 Note how I tried to click "Choose Area" instead of "Create neighborhood" at 00:12s. I should copy the "active tool" style from the edit tools, I'll do that right now, should be quick).

Here's how the breadcrumbs look with a pathologically long name on a very narrow screen:

If it's an "inner" breadcrumb, we truncate it:

<img width="868" alt="Screenshot 2025-04-04 at 15 49 28" src="https://github.com/user-attachments/assets/893869e7-64de-4631-a9a1-a6878a075107" />


If it's the final breadcrumb (the current page), we unfurl the full name in all its glory - so the user can see the full name.

<img width="868" alt="Screenshot 2025-04-04 at 15 49 22" src="https://github.com/user-attachments/assets/b0eb73fe-c49b-4e6c-8292-d6ffa234521b" />

Not great... but there's only so much we can do!

Note: The max-size is defined in units of `vw`, so we'll truncate less on wider screens.


---

Also: With the project and neighbourhood names in the breadcrumb, their appearance elsewhere was feeling redundant, so I removed them.

Here's what it looked like after adding the names to the breadcrumbs, but before removing the redundancy:

**before**:

<img width="1624" alt="Screenshot 2025-04-04 at 15 55 04" src="https://github.com/user-attachments/assets/7a444e6f-4b5b-4930-8bd8-7e84495d0f8b" />

**after**:

<img width="1624" alt="Screenshot 2025-04-04 at 15 56 51" src="https://github.com/user-attachments/assets/cc607de1-f315-4777-8fbc-9de752625092" />


