### PR TITLE
Add neighbourhood: Distinguish tabs buttons from submit button

### DIFF
--- a/web/src/AddNeighbourhoodMode.svelte
+++ b/web/src/AddNeighbourhoodMode.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Feature, FeatureCollection, Polygon } from "geojson";
-  import { Trash2 } from "lucide-svelte";
+  import { Pencil, Pointer, Trash2 } from "lucide-svelte";
   import type { DataDrivenPropertyValueSpecification } from "maplibre-gl";
   import { onMount } from "svelte";
   import {
@@ -256,20 +256,20 @@
     <hr />
 
     <div>
-      <div class="modes">
+      <div class="tool-palette">
         <button
           on:click={() => (addMode = "choose-area")}
           class:active={addMode == "choose-area"}
-          disabled={addMode == "choose-area"}
         >
+          <Pointer />
           Choose area
         </button>
         <span style="margin: 0 16px;">or</span>
         <button
           on:click={() => (addMode = "draw-area")}
           class:active={addMode == "draw-area"}
-          disabled={addMode == "draw-area"}
         >
+          <Pencil />
           Draw area
         </button>
       </div>
@@ -352,7 +352,7 @@
         {:else}
           <span style="text-align:center;">
             {#if addMode == "choose-area"}
-              Empty so far. Click an area to get started.
+              Empty so far. Click a colored area to get started.
             {:else if addMode == "draw-area"}
               {#if waypoints.length < 3}
                 Empty so far. Click the map to add points around your
@@ -454,21 +454,8 @@
 </SplitComponent>
 
 <style>
-  .modes {
-    margin-bottom: 8px;
-  }
-  .modes button.active {
-    background-color: rgb(0, 116, 76);
-    opacity: 1;
-    color: white;
-  }
-  .modes button:not(.active):hover {
-    background-color: rgba(0, 116, 76, 0.5);
-  }
-  .modes button {
-    background-color: white;
-    color: black;
-    border: solid green 1px;
+  .tool-palette {
+    margin-bottom: 16px;
   }
   .neighbourhood-boundary-summary {
     border: dashed black 2px;

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -336,7 +336,8 @@
   }
 
   :global(.pico button.icon-btn):hover,
-  :global(button.icon-btn):hover {
+  :global(button.icon-btn):hover,
+  :global(.pico .tool-palette button:hover) {
     background-color: #ddd;
   }
 

--- a/web/src/edit/NeighbourhoodMode.svelte
+++ b/web/src/edit/NeighbourhoodMode.svelte
@@ -377,10 +377,8 @@
       <div style="display: flex; justify-content: left; gap: 8px;">
         <button
           on:click={() => (action = { kind: "filter", freehand: false })}
-          disabled={action.kind == "filter"}
           class="icon-btn"
           class:active={action.kind == "filter"}
-          class:outline={action.kind != "filter"}
           data-tooltip="Add a modal filter (hotkey 1)"
         >
           <img
@@ -390,10 +388,8 @@
         </button>
         <button
           on:click={() => (action = { kind: "oneway" })}
-          disabled={action.kind == "oneway"}
           class="icon-btn"
           class:active={action.kind == "oneway"}
-          class:outline={action.kind != "oneway"}
           data-tooltip="Toggle one-way (hotkey 2)"
         >
           <!-- 
@@ -415,10 +411,8 @@
         </button>
         <button
           on:click={() => (action = startTurnRestrictionAction())}
-          disabled={action.kind == "turn_restriction"}
           class="icon-btn"
           class:active={action.kind == "turn_restriction"}
-          class:outline={action.kind != "turn_restriction"}
           data-tooltip="Restrict turns (hotkey 3)"
         >
           <img
@@ -429,10 +423,8 @@
         <button
           on:click={() =>
             (action = { kind: "main-roads", freehand: false, isMain: false })}
-          disabled={action.kind == "main-roads"}
           class="icon-btn"
           class:active={action.kind == "main-roads"}
-          class:outline={action.kind != "main-roads"}
           data-tooltip="Reclassify main roads (hotkey 4)"
         >
           <img src={mainRoadIconUrl} alt="Change main/minor roads" />
@@ -726,32 +718,50 @@
 </SplitComponent>
 
 <style>
-  .tool-palette button {
-    padding: 8px;
+  :global(.pico .tool-palette button) {
+    padding: 12px;
     margin: 0;
+    background: none;
+    color: black;
+  }
+
+  :global(.pico .tool-palette button.icon-btn) {
+    padding: 8px;
     height: 100%;
     aspect-ratio: 1;
   }
-  .tool-palette button img {
+
+  :global(.pico .tool-palette button.icon-btn img) {
     aspect-ratio: 1;
     height: 100%;
     width: auto;
     object-fit: contain;
   }
-  .tool-palette button.active:disabled {
+
+  :global(.pico .tool-palette button.active) {
     /* slightly increased border */
     border: 2px solid black;
     /* Slightly decreased padding to account for the slightly increased border */
-    padding: 7px;
-
-    /* picocss default color is very dark */
-    background: rgb(124, 190, 146);
+    padding: 11px;
     /* picocss disabled override */
     opacity: 1;
   }
+
+  :global(.pico .tool-palette button.icon-btn.active) {
+    /* Slightly decreased padding to account for the slightly increased border */
+    padding: 7px;
+  }
+
+  :global(.pico .tool-palette button.active),
+  :global(.pico .tool-palette button.active:hover) {
+    /* picocss default color is very dark */
+    background: rgb(124, 190, 146);
+  }
+
   .classification-buttons {
     width: fit-content;
   }
+
   .footnote-ref {
     font-size: 70%;
     color: var(--pico-secondary);


### PR DESCRIPTION
FIXES #314 

**before:** tool picker and submit button are styled the same

<img width="1624" alt="Screenshot 2025-04-04 at 17 05 14" src="https://github.com/user-attachments/assets/26526640-ffd4-44f6-948b-1fd1af8176f3" />

**after:** The tool tabs now have a distinct style

<img width="1624" alt="Screenshot 2025-04-04 at 17 05 36" src="https://github.com/user-attachments/assets/ebfac734-36c9-4581-9e1a-665e0608ac69" />

Hopefully it's enough for me to stop trying to click the wrong button...