### PR TITLE
FIX: undoing no-op classifications changes classification

### DIFF
--- a/backend/src/create.rs
+++ b/backend/src/create.rs
@@ -247,6 +247,7 @@ pub fn create_from_osm(
 
         undo_stack: Vec::new(),
         redo_stack: Vec::new(),
+        reclassifications_in_progress: BTreeSet::new(),
         boundaries: BTreeMap::new(),
         context_data,
     };


### PR DESCRIPTION
FIXES #315 

Now, we only add to the undo stack the roads which were actually changed:

https://github.com/user-attachments/assets/0b2fc721-56cc-4375-b831-570f57e1b964

