### PR TITLE
Simplify generated waypoints from "picked" neighbourhoods.

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -208,7 +208,7 @@ impl LTN {
         let geojson_geometry: Geometry = serde_wasm_bindgen::from_value(js_polygon)?;
 
         let Ok(mut ring) = geo::LineString::try_from(geojson_geometry) else {
-            return Err("invalid Polygon GeoJSON".into());
+            return Err("invalid LineString GeoJSON".into());
         };
         self.map.mercator.to_mercator_in_place(&mut ring);
         let mut waypoints = WayPoint::waypoints_for_ring(&ring);

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -154,6 +154,11 @@ export class Backend {
     this.inner.setCurrentNeighbourhoodBoundary(name, input);
   }
 
+  extractWaypointsFromRing(line_string: LineString): Waypoint[] {
+    let serializedWaypoints = this.inner.extractWaypointsFromRing(line_string);
+    return JSON.parse(serializedWaypoints);
+  }
+
   deleteNeighbourhoodBoundary(name: string) {
     this.inner.deleteNeighbourhoodBoundary(name);
   }


### PR DESCRIPTION
FIXES #201 

You can create your neighbourhood "by hand" or by picking from a set of generated "severance" blocks.

Typically starting with the generated severance blocks is easier, but it's common that you also want to tweak the boundary a little bit to include/exclude some roads on the edge.

Adjust boundaries means manipulating the placement of Waypoints. For hand-drawn neighbourhoods, this is easy - we store the Waypoints placed by the user when they were drawing the neighbourhood initially.

For generated boundaries this is trickier. Previously, we simply generated a waypoint for every single vertex in the polygon. Because these shapes could be a bit complex, we'd easily end up with hundreds of waypoints. In practice, editing one of these neighbourhoods was very tedious.

The change here, is to apply a line simplification to the border, greatly reducing the number of waypoints.

Simplification, by it's nature, removes some fidelity of the polygon's exterior, so it's possible that we'll add/lose some roads on the edge of a boundary. My own testing shows this to be minimal and usually ignorable.

When it *does* introduce a non-ignorable problem, the user will need to go back and further refine the boundary.

We could further reduce the possibility of error by decreasing the `epsilon` value for the simplification algorithm, but that also means including more points.

In my own testing, I feel like the benefits of having a simpler polygon to start with outweighs the downsides of any jitter on the edge, and the current value is about right.


Before on the left (350+ points) after on the right (30ish points)

<img width="2304" alt="Screenshot 2025-04-08 at 10 53 32" src="https://github.com/user-attachments/assets/f05d1491-be74-40ec-9a49-0cb513f8170c" />
