### PR TITLE
Link to "predict impact" mode from "neighbourhood" mode.

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -246,13 +246,6 @@ impl LTN {
         self.neighbourhood =
             Some(Neighbourhood::new(&self.map, boundary.clone()).map_err(err_to_js)?);
 
-        // We can delete this assert if it's a valid code path, but I think it's not.
-        // If we haven't triggered it after a while, we can delete the editing_same logic.
-        debug_assert!(
-            !editing_same,
-            "I don't think this happens anymore since we got rid of 'edit_perimeter_roads'"
-        );
-
         // Undoing edits in another neighbourhood doesn't make sense
         if !editing_same {
             self.map.undo_stack.clear();

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -277,9 +277,12 @@
             {:else if $mode.mode == "route"}
               <RouteMode prevMode={$mode.prevMode} />
             {:else if $mode.mode == "predict-impact"}
-              <PredictImpactMode />
+              <PredictImpactMode prevMode={$mode.prevMode} />
             {:else if $mode.mode == "impact-detail"}
-              <ImpactDetailMode road={$mode.road} />
+              <ImpactDetailMode
+                road={$mode.road}
+                prevPrevMode={$mode.prevPrevMode}
+              />
             {:else if $mode.mode == "debug-neighbourhood"}
               <DebugNeighbourhoodMode />
             {:else if $mode.mode == "debug-intersections"}

--- a/web/src/DebugDemandMode.svelte
+++ b/web/src/DebugDemandMode.svelte
@@ -83,7 +83,9 @@
           <ModeLink mode={{ mode: "pick-neighbourhood" }} />
         </li>
         <li>
-          <ModeLink mode={{ mode: "predict-impact" }} />
+          <ModeLink
+            mode={{ mode: "predict-impact", prevMode: "pick-neighbourhood" }}
+          />
         </li>
         <li>{pageTitle($mode.mode)}</li>
       </ul>
@@ -91,7 +93,9 @@
   </div>
 
   <div slot="sidebar">
-    <BackButton mode={{ mode: "predict-impact" }} />
+    <BackButton
+      mode={{ mode: "predict-impact", prevMode: "pick-neighbourhood" }}
+    />
 
     <!-- TODO Plumb through metadata about the sources used -->
 

--- a/web/src/ImpactDetailMode.svelte
+++ b/web/src/ImpactDetailMode.svelte
@@ -19,6 +19,7 @@
   import type { ImpactOnRoad } from "./wasm";
 
   export let road: Feature;
+  export let prevPrevMode: "pick-neighbourhood" | "neighbourhood";
 
   // TODO Weird to modify the input like this?
   let props = road.properties!;
@@ -42,7 +43,7 @@
       window.alert(
         "No routes over this road change. (This is a bug in progress of being fixed.)",
       );
-      $mode = { mode: "predict-impact" };
+      $mode = { mode: "predict-impact", prevMode: prevPrevMode };
     }
   });
 
@@ -83,13 +84,21 @@
         <li>
           <ModeLink mode={{ mode: "pick-neighbourhood" }} />
         </li>
+        {#if prevPrevMode == "neighbourhood"}
+          <li>
+            <ModeLink mode={{ mode: "neighbourhood" }} />
+          </li>
+        {/if}
+        <li>
+          <ModeLink mode={{ mode: "predict-impact", prevMode: prevPrevMode }} />
+        </li>
         <li>{pageTitle($mode.mode)}</li>
       </ul>
     </nav>
   </div>
 
   <div slot="sidebar">
-    <BackButton mode={{ mode: "predict-impact" }} />
+    <BackButton mode={{ mode: "predict-impact", prevMode: prevPrevMode }} />
 
     <p>
       {props.before.toLocaleString()} routes cross here

--- a/web/src/PickNeighbourhoodMode.svelte
+++ b/web/src/PickNeighbourhoodMode.svelte
@@ -179,7 +179,9 @@
           <ModeLink mode={{ mode: "route", prevMode: "pick-neighbourhood" }} />
         </li>
         <li>
-          <ModeLink mode={{ mode: "predict-impact" }} />
+          <ModeLink
+            mode={{ mode: "predict-impact", prevMode: "pick-neighbourhood" }}
+          />
         </li>
         {#if $devMode}
           <li>

--- a/web/src/PredictImpactMode.svelte
+++ b/web/src/PredictImpactMode.svelte
@@ -10,6 +10,8 @@
   import { backend, fastSample, minImpactCount, mode } from "./stores";
   import type { Impact } from "./wasm";
 
+  export let prevMode: "pick-neighbourhood" | "neighbourhood";
+
   // Based partly on https://colorbrewer2.org/#type=diverging&scheme=RdYlGn&n=5
   // The middle color white doesn't matter; the source data will filter out unchanged roads
   let divergingScale = ["#1a9641", "#a6d96a", "white", "#fdae61", "#d7191c"];
@@ -27,7 +29,7 @@
   let maxRoadWidth = 10;
 
   function pickRoad(f: Feature) {
-    $mode = { mode: "impact-detail", road: f };
+    $mode = { mode: "impact-detail", road: f, prevPrevMode: prevMode };
   }
 
   async function recalculate(fastSample: boolean) {
@@ -61,13 +63,18 @@
         <li>
           <ModeLink mode={{ mode: "pick-neighbourhood" }} />
         </li>
+        {#if prevMode == "neighbourhood"}
+          <li>
+            <ModeLink mode={{ mode: "neighbourhood" }} />
+          </li>
+        {/if}
         <li>{pageTitle($mode.mode)}</li>
       </ul>
     </nav>
   </div>
 
   <div slot="sidebar">
-    <BackButton mode={{ mode: "pick-neighbourhood" }} />
+    <BackButton mode={{ mode: prevMode }} />
 
     <p>
       This mode estimates the impact of all your changes on traffic around the

--- a/web/src/common/navbar.ts
+++ b/web/src/common/navbar.ts
@@ -16,7 +16,7 @@ export function pageTitle(mode: Mode["mode"]): string {
     case "neighbourhood":
       return get(currentNeighbourhoodName) || "Editing"; // TODO truncate if necessary
     case "view-shortcuts":
-      return "View shortcuts";
+      return "Shortcuts";
     case "impact-one-destination":
       return "Impact on one destination";
     case "route":

--- a/web/src/edit/NeighbourhoodMode.svelte
+++ b/web/src/edit/NeighbourhoodMode.svelte
@@ -324,6 +324,11 @@
           <ModeLink mode={{ mode: "route", prevMode: "neighbourhood" }} />
         </li>
         <li>
+          <ModeLink
+            mode={{ mode: "predict-impact", prevMode: "neighbourhood" }}
+          />
+        </li>
+        <li>
           <ModeLink mode={{ mode: "impact-one-destination" }} />
         </li>
         <li>

--- a/web/src/stores.ts
+++ b/web/src/stores.ts
@@ -55,10 +55,12 @@ export type Mode =
     }
   | {
       mode: "predict-impact";
+      prevMode: "pick-neighbourhood" | "neighbourhood";
     }
   | {
       mode: "impact-detail";
       road: Feature;
+      prevPrevMode: "pick-neighbourhood" | "neighbourhood";
     }
   | {
       mode: "debug-intersections";


### PR DESCRIPTION
FIXES #281 

One shortcut I took is opting out of tracking the "true" back state for
the DebugDemandMode, accessible via PredictImpactDetailMode. We just
always go back to pick-neighbouhood. I don't think people will get very
confused by this in practice.

If we want to continue to simulate a stack properly so that hitting "back" 3 times
returns you to the same page from DebugDemandMode, we'd need to track
`prevPrevPrevMode` which seems a bit much.

At some point it might make sense to track an explicit stack of previous
`modes`, rather than trying to manually track the "prevMode" and
"prevPrevMode".