### PR TITLE
Recreation POIs

### DIFF
--- a/backend/src/boundary_stats.rs
+++ b/backend/src/boundary_stats.rs
@@ -289,4 +289,5 @@ pub enum POIKind {
     Grocery,
     Hospital,
     School,
+    Recreation,
 }

--- a/data_prep/scotland/src/bin/generate_prioritization.rs
+++ b/data_prep/scotland/src/bin/generate_prioritization.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use backend::boundary_stats::{ContextData, POIKind, PopulationZone, POI};
 use data_prep::{PopulationZoneInput, StudyArea};
 use geo::{MultiPolygon, Point, Relate};
@@ -111,9 +111,10 @@ impl InputPOI {
             ("tmp/gp_practices.geojson", POIKind::GP),
             ("tmp/hospitals.geojson", POIKind::Hospital),
             ("tmp/schools.geojson", POIKind::School),
+            ("out_layers/recreation.geojson", POIKind::Recreation),
         ] {
             let input: Vec<InputPOI> = geojson::de::deserialize_feature_collection_str_to_vec(
-                &fs_err::read_to_string(path)?,
+                &fs_err::read_to_string(path).context(format!("opening {path}"))?,
             )?;
             for poi in input {
                 pois.push(POI {
@@ -173,7 +174,7 @@ impl CarOwnershipDataZone {
     fn read_all_from_file() -> Result<Vec<Self>> {
         let input_path = "input/car_ownership_data_zones.csv";
         let mut output = vec![];
-        for rec in csv::Reader::from_path(input_path)?.deserialize() {
+        for rec in csv::Reader::from_path(input_path).context(format!("opening {input_path}"))?.deserialize() {
             let rec: Self = rec?;
             debug_assert_eq!(
                 rec.total_households,

--- a/web/src/context/POIs.svelte
+++ b/web/src/context/POIs.svelte
@@ -6,13 +6,14 @@
 
   let show = false;
 
-  // https://colorbrewer2.org/#type=qualitative&scheme=Accent&n=5
+  // https://colorbrewer2.org/#type=qualitative&scheme=Accent&n=6
   let labelColors = {
     School: "#7fc97f",
     GP: "#beaed4",
     Hospital: "#fdc086",
     Grocery: "#386cb0",
     CommunityCenter: "#ffff99",
+    Recreation: "#f0027f",
   };
 </script>
 
@@ -64,6 +65,7 @@
         "circle-radius": 10,
         "circle-stroke-color": "black",
         "circle-stroke-width": 1,
+        "circle-opacity": 0.8,
       }}
       layout={{
         visibility: show ? "visible" : "none",


### PR DESCRIPTION
FIXES #233 

We should have sustrans take a sanity pass at our categories.

<img width="1624" alt="Screenshot 2025-04-08 at 16 44 17" src="https://github.com/user-attachments/assets/05f4f5f1-9446-417b-b6b8-25932a69d498" />


Zooming in you can see how the recreation POI's often correspond with the map data POIs
<img width="1624" alt="Screenshot 2025-04-08 at 16 44 31" src="https://github.com/user-attachments/assets/dad9301e-ddef-4571-99cc-9cb87157545c" />

I was tempted to add restaurants and fast_food, as they are likely destinations, but I couldn't justify filing taco bell under recreation.

