### PR TITLE
Fix: tooltips off screen and introduce undesirable scrolling

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,7 +15,8 @@
         "route-snapper": "^0.4.9",
         "route-snapper-ts": "^0.0.8",
         "svelte-maplibre": "^0.9.14",
-        "svelte-utils": "github:a-b-street/svelte-utils"
+        "svelte-utils": "github:a-b-street/svelte-utils",
+        "tippy.js": "^6.3.7"
       },
       "devDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "^4.4.0",
@@ -1101,6 +1102,16 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.35.0",
@@ -5155,6 +5166,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
       }
     },
     "node_modules/tldts": {

--- a/web/package.json
+++ b/web/package.json
@@ -39,6 +39,7 @@
     "route-snapper": "^0.4.9",
     "route-snapper-ts": "^0.0.8",
     "svelte-maplibre": "^0.9.14",
-    "svelte-utils": "github:a-b-street/svelte-utils"
+    "svelte-utils": "github:a-b-street/svelte-utils",
+    "tippy.js": "^6.3.7"
   }
 }

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -58,6 +58,7 @@
   import NewProjectMode from "./title/NewProjectMode.svelte";
   import TitleMode from "./title/TitleMode.svelte";
   import ViewShortcutsMode from "./ViewShortcutsMode.svelte";
+  import "tippy.js/dist/tippy.css";
 
   export let appFocus: AppFocus = "global";
   appFocusStore.set(appFocus);

--- a/web/src/common/PrevNext.svelte
+++ b/web/src/common/PrevNext.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
+  import { initTooltips } from ".";
   import { map } from "../stores";
 
   export let list: any[];
@@ -7,6 +8,7 @@
 
   onMount(() => {
     $map?.keyboard.disable();
+    initTooltips();
   });
   onDestroy(() => {
     $map?.keyboard.enable();
@@ -41,14 +43,14 @@
 <div
   style="display: flex; justify-content: space-between; align-items: center;"
 >
-  <button disabled={idx == 0} on:click={prev} data-tooltip="Left">
+  <button disabled={idx == 0} on:click={prev} data-tippy-content="Left">
     Previous
   </button>
   {idx + 1} / {list.length}
   <button
     disabled={idx == list.length - 1}
     on:click={next}
-    data-tooltip="Right"
+    data-tippy-content="Right"
   >
     Next
   </button>

--- a/web/src/common/index.ts
+++ b/web/src/common/index.ts
@@ -4,6 +4,7 @@ import type {
 } from "maplibre-gl";
 import { downloadGeneratedFile } from "svelte-utils";
 import { get } from "svelte/store";
+import tippy from "tippy.js";
 import { appFocus, projectStorage } from "../stores";
 import { type ProjectID, type StudyAreaName } from "./ProjectStorage";
 
@@ -27,6 +28,14 @@ export function gjPosition(pt: number[]): [number, number] {
   return pt as [number, number];
 }
 
+/// Any component using tooltips must call this in onMount
+///
+/// Add tooltips like this:
+///   <button data-tippy-content="My Tooltip">...</button>;
+/// Then call this method in onMount:
+export function initTooltips() {
+  tippy("[data-tippy-content]");
+}
 // Zoom-dependant line width, adapted from from the Minor road layer (secondary
 // road class) from https://api.maptiler.com/maps/streets-v2/style.json.
 export function roadLineWidth(extraWidth: number): ExpressionSpecification {

--- a/web/src/edit/NeighbourhoodMode.svelte
+++ b/web/src/edit/NeighbourhoodMode.svelte
@@ -2,7 +2,7 @@
   import type { Feature, FeatureCollection, LineString } from "geojson";
   import { Eraser, Paintbrush, Pointer, Redo, Undo } from "lucide-svelte";
   import type { LngLat, MapMouseEvent } from "maplibre-gl";
-  import { onDestroy } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import {
     GeoJSON,
     hoverStateFilter,
@@ -20,6 +20,7 @@
   import AnimatePaths from "../AnimatePaths.svelte";
   import {
     HelpButton,
+    initTooltips,
     layerId,
     ModeLink,
     pageTitle,
@@ -124,6 +125,9 @@
       f.properties.kind == "cell" && f.properties.cell_color == "disconnected",
   ).length;
 
+  onMount(() => {
+    initTooltips();
+  });
   onDestroy(() => {
     $map!.doubleClickZoom.enable();
   });
@@ -359,7 +363,7 @@
           on:click={() => (action = { kind: "filter", freehand: false })}
           class="icon-btn"
           class:active={action.kind == "filter"}
-          data-tooltip="Add a modal filter (hotkey 1)"
+          data-tippy-content="Add a modal filter (hotkey 1)"
         >
           <img
             src={notNull(ModalFilterType.getFilter($currentFilterType)).iconURL}
@@ -370,7 +374,7 @@
           on:click={() => (action = { kind: "oneway" })}
           class="icon-btn"
           class:active={action.kind == "oneway"}
-          data-tooltip="Toggle one-way (hotkey 2)"
+          data-tippy-content="Toggle one-way (hotkey 2)"
         >
           <!-- 
          cheat the default padding just a bit with negative placement, 
@@ -393,7 +397,7 @@
           on:click={() => (action = startTurnRestrictionAction())}
           class="icon-btn"
           class:active={action.kind == "turn_restriction"}
-          data-tooltip="Restrict turns (hotkey 3)"
+          data-tippy-content="Restrict turns (hotkey 3)"
         >
           <img
             src={`${import.meta.env.BASE_URL}/filters/no_right_turn.svg`}
@@ -405,7 +409,7 @@
             (action = { kind: "main-roads", freehand: false, isMain: false })}
           class="icon-btn"
           class:active={action.kind == "main-roads"}
-          data-tooltip="Reclassify main roads (hotkey 4)"
+          data-tippy-content="Reclassify main roads (hotkey 4)"
         >
           <img src={mainRoadIconUrl} alt="Change main/minor roads" />
         </button>
@@ -415,7 +419,7 @@
           class="outline icon-btn"
           disabled={undoLength == 0}
           on:click={undo}
-          data-tooltip={undoLength == 0
+          data-tippy-content={undoLength == 0
             ? "Undo Ctrl+Z"
             : `Undo (${undoLength}) Ctrl+Z`}
         >
@@ -425,7 +429,7 @@
           class="outline icon-btn"
           disabled={redoLength == 0}
           on:click={redo}
-          data-tooltip={redoLength == 0
+          data-tippy-content={redoLength == 0
             ? "Redo Ctrl+Y"
             : `Redo (${redoLength}) Ctrl+Y`}
         >
@@ -456,7 +460,7 @@
               : () => (action = { kind: "filter", freehand: true })}
             class:active={action.freehand}
             class:outline={!action.freehand}
-            data-tooltip="Add many modal filters along a line"
+            data-tippy-content="Add many modal filters along a line"
           >
             <div style="display: flex; align-items: center; gap: 8px;">
               <Paintbrush />
@@ -501,7 +505,7 @@
             }}
             class:active={!action.freehand}
             class:outline={action.freehand}
-            data-tooltip="Click a road to reclassify it"
+            data-tippy-content="Click a road to reclassify it"
           >
             <div style="display: flex; align-items: center; gap: 8px;">
               <Pointer />
@@ -514,7 +518,7 @@
             }}
             class:active={action.freehand && action.isMain}
             class:outline={!(action.freehand && action.isMain)}
-            data-tooltip="Reclassify multiple roads by drawing a line along them"
+            data-tippy-content="Reclassify multiple roads by drawing a line along them"
           >
             <div style="display: flex; align-items: center; gap: 8px;">
               <Paintbrush />
@@ -527,7 +531,7 @@
             }}
             class:active={action.freehand && !action.isMain}
             class:outline={!(action.freehand && !action.isMain)}
-            data-tooltip="Reclassify multiple roads by drawing a line along them"
+            data-tippy-content="Reclassify multiple roads by drawing a line along them"
           >
             <div style="display: flex; align-items: center; gap: 8px;">
               <Eraser />
@@ -550,7 +554,7 @@
       <input type="checkbox" bind:checked={$animateShortcuts} />
       Animate shortcuts<span
         class="footnote-ref"
-        data-tooltip={shortcutDescriptionText}>1</span
+        data-tippy-content={shortcutDescriptionText}>1</span
       >
     </label>
 
@@ -558,7 +562,7 @@
       <input type="checkbox" bind:checked={$drawBorderEntries} />
       Show entries into cells<span
         class="footnote-ref"
-        data-tooltip={cellsDescriptionText}>2</span
+        data-tippy-content={cellsDescriptionText}>2</span
       >
     </label>
 
@@ -566,7 +570,7 @@
       <input type="checkbox" bind:checked={$thickRoadsForShortcuts} />
       Road thickness depends on shortcuts<span
         class="footnote-ref"
-        data-tooltip={shortcutDescriptionText}>1</span
+        data-tippy-content={shortcutDescriptionText}>1</span
       >
     </label>
 
@@ -752,13 +756,10 @@
   .footnote-ref {
     font-size: 70%;
     color: var(--pico-secondary);
+    text-decoration: underline;
+    cursor: help;
     position: relative;
     top: -12px;
     left: 4px;
-  }
-  :global(.pico .footnote-ref[data-tooltip]:hover::before) {
-    max-width: 400px;
-    min-width: 300px;
-    text-wrap: auto;
   }
 </style>


### PR DESCRIPTION
Instead employ tippy.js

picocss tooltips were nice because they were completely declarative. However plain css wasn't powerful enough - we need more information about the current layout to position the tooltip visibly in some cases, which requires js.

Specific examples:

1. The "Add modal filter" button, had its tooltip mostly off the left edge of the screen.
2. Symmetrically, the "Redo" button, had its tooltip cropped off by the right edge of the left panel.
3. The "Redo" button and the "footnote" tooltips caused the left panel to be wider than necessary, even when they weren't being displayed, which introduced an undesirable (and very hard to track down!!!) horizontal scroll in the left panel.

The downside to this new non-declarative approach is that every component needs to initialize their tooltips by calling `initTooltips`. If a new component is rendered afterwards, its tooltips will not be initialized.

**before: **

<img width="366" alt="Screenshot 2025-04-10 at 16 57 48" src="https://github.com/user-attachments/assets/a7701511-4566-4c60-882e-2824903c7daa" />

**after: **

<img width="409" alt="Screenshot 2025-04-10 at 16 57 38" src="https://github.com/user-attachments/assets/1dcf54ab-7dd4-499c-89d1-09658896d524" />
