### PR TITLE
smaller left panel

### DIFF
--- a/web/src/AddNeighbourhoodMode.svelte
+++ b/web/src/AddNeighbourhoodMode.svelte
@@ -260,7 +260,10 @@
     <hr />
 
     <div>
-      <div class="tool-palette">
+      <div
+        class="tool-palette"
+        style="display: flex; align-items: center; gap: 16px;"
+      >
         <button
           on:click={() => (addMode = "choose-area")}
           class:active={addMode == "choose-area"}
@@ -268,7 +271,7 @@
           <Pointer />
           Choose area
         </button>
-        <span style="margin: 0 16px;">or</span>
+        or
         <button
           on:click={() => (addMode = "draw-area")}
           class:active={addMode == "draw-area"}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -307,16 +307,17 @@
   }
 
   :global(#app .left) {
-    width: 35%;
-    min-width: 400px;
-    max-width: 700px;
+    width: 30%;
+    min-width: 350px;
+    max-width: 500px;
     box-shadow: 2px 0 5px rgba(0, 0, 0, 0.4);
     /* so box-shadow falls onto .main (the map) */
     z-index: 1;
   }
 
   :global(#app .main) {
-    width: 65%;
+    width: auto;
+    flex: 1;
   }
 
   :global(.pico button.icon-btn.destructive),

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -308,7 +308,7 @@
 
   :global(#app .left) {
     width: 30%;
-    min-width: 350px;
+    min-width: 400px;
     max-width: 500px;
     box-shadow: 2px 0 5px rgba(0, 0, 0, 0.4);
     /* so box-shadow falls onto .main (the map) */
@@ -320,14 +320,18 @@
     flex: 1;
   }
 
+  :global(#app .pico button) {
+    padding: 4px 8px;
+  }
+
   :global(.pico button.icon-btn.destructive),
   :global(button.icon-btn.destructive),
   :global(.pico button.destructive) {
     background-color: #dc2626;
   }
 
-  :global(.pico button.icon-btn),
-  :global(button.icon-btn) {
+  :global(#app .pico button.icon-btn),
+  :global(#app button.icon-btn) {
     margin: 0;
     padding: 6px;
     display: flex;
@@ -340,46 +344,96 @@
     border-color: black;
   }
 
-  :global(.pico button.icon-btn):hover,
-  :global(button.icon-btn):hover,
-  :global(.pico .tool-palette button:hover) {
+  :global(#app .pico button.icon-btn):hover,
+  :global(#app button.icon-btn):hover,
+  :global(#app .pico .tool-palette button:hover) {
     background-color: #ddd;
   }
 
-  :global(.pico button.icon-btn.destructive):hover,
-  :global(button.icon-btn.destructive):hover {
+  :global(#app.pico button.icon-btn.destructive):hover,
+  :global(#app button.icon-btn.destructive):hover {
     background-color: #891717;
   }
 
-  :global(.pico button.icon-btn svg),
-  :global(button.icon-btn svg) {
+  :global(#app .pico button.icon-btn svg),
+  :global(#app button.icon-btn svg) {
     height: 100%;
     width: auto;
     aspect-ratio: 1;
     object-fit: contain;
   }
 
-  :global(.pico nav[aria-label="breadcrumb"] ul) {
+  :global(#app .pico .tool-palette button) {
+    padding: 12px;
+    margin: 0;
+    background: none;
+    color: black;
+  }
+
+  :global(#app .pico .tool-palette button.icon-btn) {
+    padding: 8px;
+    height: 100%;
+    aspect-ratio: 1;
+  }
+
+  :global(#app .pico .tool-palette button.icon-btn img) {
+    aspect-ratio: 1;
+    height: 100%;
+    width: auto;
+    object-fit: contain;
+  }
+
+  :global(#app .pico .tool-palette button.active) {
+    /* slightly increased border */
+    border: 2px solid black;
+    /* Slightly decreased padding to account for the slightly increased border */
+    padding: 11px;
+    /* picocss disabled override */
+    opacity: 1;
+  }
+
+  :global(#app .pico .tool-palette button.icon-btn.active) {
+    /* Slightly decreased padding to account for the slightly increased border */
+    padding: 7px;
+  }
+
+  :global(#app .pico .tool-palette button.active),
+  :global(#app .pico .tool-palette button.active:hover) {
+    /* picocss default color is very dark */
+    background: rgb(124, 190, 146);
+  }
+
+  :global(#app .pico [type="checkbox"]),
+  :global(#app .pico [type="radio"]) {
+    width: 1em;
+    height: 1em;
+    margin-inline-end: 4px;
+  }
+
+  :global(#app .pico nav[aria-label="breadcrumb"] ul) {
     margin-left: 4px;
   }
 
-  :global(.pico nav[aria-label="breadcrumb"] ul > li) {
+  :global(#app .pico nav[aria-label="breadcrumb"] ul > li) {
     display: flex;
     align-items: center;
     gap: 4px;
   }
 
-  :global(.pico nav[aria-label="breadcrumb"] ul li:before) {
+  :global(#app .pico nav[aria-label="breadcrumb"] ul li:before) {
     /* pico overrides to reconcile breadcrumb li becoming `flex` */
     display: none;
   }
 
-  :global(.pico nav[aria-label="breadcrumb"] ul li:not(:last-child)::after) {
+  :global(
+    #app .pico nav[aria-label="breadcrumb"] ul li:not(:last-child)::after
+  ) {
     /* pico overrides to reconcile breadcrumb li becoming `flex` */
     position: static;
     margin-right: -32px;
     margin-left: -16px;
   }
+
   :global(.pico nav[aria-label="breadcrumb"] ul li:last-child) {
     font-size: 110%;
     font-weight: bold;
@@ -453,7 +507,7 @@
     background: #ddd;
   }
 
-  :global(.top .pico button) {
+  :global(#app .top .pico button) {
     background: white;
     height: 40px;
     width: 40px;

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -308,8 +308,8 @@
 
   :global(#app .left) {
     width: 30%;
-    min-width: 400px;
-    max-width: 500px;
+    min-width: 300px;
+    max-width: 450px;
     box-shadow: 2px 0 5px rgba(0, 0, 0, 0.4);
     /* so box-shadow falls onto .main (the map) */
     z-index: 1;
@@ -321,7 +321,7 @@
   }
 
   :global(#app .pico button) {
-    padding: 4px 8px;
+    padding: 6px 14px;
   }
 
   :global(.pico button.icon-btn.destructive),
@@ -364,14 +364,13 @@
   }
 
   :global(#app .pico .tool-palette button) {
-    padding: 12px;
     margin: 0;
     background: none;
     color: black;
   }
 
   :global(#app .pico .tool-palette button.icon-btn) {
-    padding: 8px;
+    padding: 6px;
     height: 100%;
     aspect-ratio: 1;
   }
@@ -386,15 +385,11 @@
   :global(#app .pico .tool-palette button.active) {
     /* slightly increased border */
     border: 2px solid black;
-    /* Slightly decreased padding to account for the slightly increased border */
-    padding: 11px;
-    /* picocss disabled override */
-    opacity: 1;
   }
 
   :global(#app .pico .tool-palette button.icon-btn.active) {
     /* Slightly decreased padding to account for the slightly increased border */
-    padding: 7px;
+    padding: 5px;
   }
 
   :global(#app .pico .tool-palette button.active),
@@ -403,11 +398,17 @@
     background: rgb(124, 190, 146);
   }
 
+  /* Form Controls */
   :global(#app .pico [type="checkbox"]),
   :global(#app .pico [type="radio"]) {
     width: 1em;
     height: 1em;
     margin-inline-end: 4px;
+  }
+
+  :global(#app .pico select) {
+    padding: 4px 40px 4px 8px;
+    margin: 8px;
   }
 
   :global(#app .pico nav[aria-label="breadcrumb"] ul) {

--- a/web/src/PickNeighbourhoodMode.svelte
+++ b/web/src/PickNeighbourhoodMode.svelte
@@ -198,7 +198,7 @@
     >
       <h2>Neighbourhoods</h2>
       <button
-        class="outline icon-btn"
+        class="outline"
         style="margin-right: 8px;"
         title="Download project as GeoJSON"
         on:click={() => downloadProject(notNull($currentProjectID))}

--- a/web/src/edit/NeighbourhoodMode.svelte
+++ b/web/src/edit/NeighbourhoodMode.svelte
@@ -356,9 +356,11 @@
     <h2>Editing tools</h2>
     <div
       class="tool-palette"
-      style="height: 54px; display: flex; justify-content: space-between; gap: 32px;"
+      style="display: flex; justify-content: space-between; flex-wrap: wrap; gap: 6px;"
     >
-      <div style="display: flex; justify-content: left; gap: 8px;">
+      <div
+        style="height: 50px; display: flex; justify-content: left; gap: 6px;"
+      >
         <button
           on:click={() => (action = { kind: "filter", freehand: false })}
           class="icon-btn"
@@ -414,7 +416,9 @@
           <img src={mainRoadIconUrl} alt="Change main/minor roads" />
         </button>
       </div>
-      <div style="display: flex; justify-content: right; gap: 8px;">
+      <div
+        style="height: 50px; display: flex; justify-content: right; gap: 6px;"
+      >
         <button
           class="outline icon-btn"
           disabled={undoLength == 0}
@@ -449,7 +453,9 @@
           neighbourhood.
         </p>
         <ChangeFilterModal bind:show={settingFilterType} />
-        <div style="display: flex; gap: 8px; align-items: center;">
+        <div
+          style="display: flex; gap: 8px; align-items: leading; flex-direction: column; width: fit-content;"
+        >
           <button class="outline" on:click={() => (settingFilterType = true)}>
             Change modal filter type
           </button>
@@ -574,7 +580,9 @@
       >
     </label>
 
-    <label style="display: flex; align-items: center; gap: 8px;">
+    <label
+      style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;"
+    >
       <span style="text-wrap: nowrap;">Draw roads:</span>
       <select
         style="margin: 0; padding: 8px; width: auto;"

--- a/web/src/edit/NeighbourhoodMode.svelte
+++ b/web/src/edit/NeighbourhoodMode.svelte
@@ -464,7 +464,7 @@
           >
             <div style="display: flex; align-items: center; gap: 8px;">
               <Paintbrush />
-              <span> Add along a line </span>
+              <span>Add along a line</span>
             </div>
           </button>
         </div>
@@ -709,46 +709,6 @@
 </SplitComponent>
 
 <style>
-  :global(.pico .tool-palette button) {
-    padding: 12px;
-    margin: 0;
-    background: none;
-    color: black;
-  }
-
-  :global(.pico .tool-palette button.icon-btn) {
-    padding: 8px;
-    height: 100%;
-    aspect-ratio: 1;
-  }
-
-  :global(.pico .tool-palette button.icon-btn img) {
-    aspect-ratio: 1;
-    height: 100%;
-    width: auto;
-    object-fit: contain;
-  }
-
-  :global(.pico .tool-palette button.active) {
-    /* slightly increased border */
-    border: 2px solid black;
-    /* Slightly decreased padding to account for the slightly increased border */
-    padding: 11px;
-    /* picocss disabled override */
-    opacity: 1;
-  }
-
-  :global(.pico .tool-palette button.icon-btn.active) {
-    /* Slightly decreased padding to account for the slightly increased border */
-    padding: 7px;
-  }
-
-  :global(.pico .tool-palette button.active),
-  :global(.pico .tool-palette button.active:hover) {
-    /* picocss default color is very dark */
-    background: rgb(124, 190, 146);
-  }
-
   .classification-buttons {
     width: fit-content;
   }

--- a/web/src/prioritization/PrioritizationSelect.svelte
+++ b/web/src/prioritization/PrioritizationSelect.svelte
@@ -52,8 +52,8 @@
   }
 </script>
 
-<div style="display: flex; gap: 16px; align-items: center;">
-  <label for="prioritization-selection">Metric</label>
+<div style="display: flex; gap: 16px; align-items: center; width: fit-content;">
+  <label style="margin: 0; padding: 0;" for="prioritization-selection">Metric</label>
   <select id="prioritization-selection" bind:value={selectedPrioritization}>
     <option value="none">None</option>
     <option value="density">Density</option>


### PR DESCRIPTION
Based on #326 so merge that first.

Part of #304 

There's a handful of related changes here. I've done some QA, but it's not impossible that there are some new layout regressions.

**before: medium**
<img width="1264" alt="before-med" src="https://github.com/user-attachments/assets/9b4e9610-658f-4323-a173-67eed03ec401" />

**after: medium**
<img width="1264" alt="Screenshot 2025-04-10 at 18 04 59" src="https://github.com/user-attachments/assets/a9f1bcc8-f32f-40e0-9823-25878db477f6" />

**before: wide**
<img width="2391" alt="before-wide" src="https://github.com/user-attachments/assets/d5b89eaa-26e5-4a8c-abfc-4497a8d901b6" />

**after: wide**
<img width="2402" alt="Screenshot 2025-04-10 at 18 04 56" src="https://github.com/user-attachments/assets/7b271d67-e22c-4a3e-b842-5c9fed58c632" />


**before: narrow**
<img width="868" alt="before-narrow" src="https://github.com/user-attachments/assets/29c96911-a2c7-4851-afee-9ec2c99cfc3d" />

**after: narrow**
<img width="868" alt="Screenshot 2025-04-10 at 18 05 07" src="https://github.com/user-attachments/assets/5f25f728-b4eb-45f5-a75d-8d8cc1900e8d" />

