### PR TITLE
Right-align help buttons

### DIFF
--- a/web/src/common/ContextLayerButton.svelte
+++ b/web/src/common/ContextLayerButton.svelte
@@ -13,11 +13,13 @@
   <input style="aspect-ratio: 1.0" type="checkbox" bind:checked={show} />
   {label}
   {#if $$slots.help}
-    <HelpButton>
-      <div class="context-layer-help-content">
-        <slot name="help" />
-      </div>
-    </HelpButton>
+    <span style="margin-left: auto"
+      ><HelpButton>
+        <div class="context-layer-help-content">
+          <slot name="help" />
+        </div>
+      </HelpButton></span
+    >
   {/if}
 </button>
 {#if show && $$slots.legend}

--- a/web/src/prioritization/PrioritizationSelect.svelte
+++ b/web/src/prioritization/PrioritizationSelect.svelte
@@ -53,7 +53,9 @@
 </script>
 
 <div style="display: flex; gap: 16px; align-items: center; width: fit-content;">
-  <label style="margin: 0; padding: 0;" for="prioritization-selection">Metric</label>
+  <label style="margin: 0; padding: 0;" for="prioritization-selection"
+    >Metric</label
+  >
   <select id="prioritization-selection" bind:value={selectedPrioritization}>
     <option value="none">None</option>
     <option value="density">Density</option>


### PR DESCRIPTION
I think right-aligning cleans this up visually, what do you think?

Before:
![image](https://github.com/user-attachments/assets/c2d2fdde-ee30-48f2-a20f-7851eb965218)
After:
![image](https://github.com/user-attachments/assets/ba81ac3a-d897-4a99-b261-ec8660bcabae)
