### PR TITLE
Take diagonal filters in account for cells

### DIFF
--- a/backend/src/cells.rs
+++ b/backend/src/cells.rs
@@ -126,11 +126,11 @@ fn floodfill(map: &MapModel, start: RoadID, neighbourhood: &Neighbourhood) -> Ce
 
             for next in &map.get_i(i).roads {
                 let next_road = map.get_r(*next);
-                /*if let Some(ref filter) = map.get_i(i).modal_filter {
-                    if !filter.allows_turn(current.id, *next) {
+                if let Some(ref filter) = map.diagonal_filters.get(&i) {
+                    if !filter.allows_movement(&(current.id, *next)) {
                         continue;
                     }
-                }*/
+                }
                 if let Some(ref filter) = map.modal_filters.get(next) {
                     // Which ends of the filtered road have we reached?
                     let mut visited_start = next_road.src_i == i;


### PR DESCRIPTION
FIXES #322.

Here's a quick test case:
[diag cells-2025-04-12.geojson.txt](https://github.com/user-attachments/files/19721695/diag.cells-2025-04-12.geojson.txt)

Before, there's one big cell.
![image](https://github.com/user-attachments/assets/e83dde55-177a-4407-adce-e853a8c3f533)

After, the cells reflect the possible movements.
![image](https://github.com/user-attachments/assets/fa67ace4-f292-4a09-981c-570d55e5027d)
