### PR TITLE
When importing a new custom area, don't download and import twice

### DIFF
--- a/web/src/title/NewProjectMode.svelte
+++ b/web/src/title/NewProjectMode.svelte
@@ -9,12 +9,13 @@
     appFocus,
     assetUrl,
     backend,
+    currentProjectID,
     map,
     mode,
     projectStorage,
   } from "../stores";
   import { Backend } from "../wasm";
-  import { loadProject } from "./loader";
+  import { afterProjectLoaded, loadProject } from "./loader";
 
   let newProjectName = "";
   let example: string | null = null;
@@ -44,7 +45,11 @@
       );
 
       const projectID = $projectStorage.createProject($backend.toSavefile());
-      await loadProject(projectID);
+      // Calling loadProject would immediately re-fetch OSM data from Overpass
+      // and recreate the backend. Instead, just call some of the things
+      // it does.
+      $currentProjectID = projectID;
+      afterProjectLoaded(projectID);
       $mode = { mode: "add-neighbourhood" };
     } catch (err) {
       window.alert(`Couldn't import from Overpass: ${err}`);

--- a/web/src/title/loader.ts
+++ b/web/src/title/loader.ts
@@ -120,7 +120,7 @@ async function getInputFiles(project: ProjectFeatureCollection): Promise<{
   }
 }
 
-function afterProjectLoaded(projectID: ProjectID) {
+export function afterProjectLoaded(projectID: ProjectID) {
   // The stores are unused; the WASM API is used directly. This TS wrapper is unused.
   routeTool.set(
     new RouteTool(


### PR DESCRIPTION
I noticed something pretty awkward. Open up the dev console and create a new project from Overpass. Previously, we were downloading + importing, then immediately doing the same thing again due to calling `loadProject`. I've fixed this, verifying the console logs and making sure the new project created behaves correctly (saving changes, refreshing and loading it, etc)