### PR TITLE
Clean up generate_prioritization

### DIFF
--- a/data_prep/scotland/src/lib.rs
+++ b/data_prep/scotland/src/lib.rs
@@ -69,4 +69,8 @@ impl PopulationZoneInput {
         println!("Read {} population zones", population_zones.len());
         Ok(population_zones)
     }
+
+    pub fn area_km2(&self) -> f64 {
+        self.area / 1000.0 / 1000.0
+    }
 }


### PR DESCRIPTION
This isn't really a big deal, but a followup to #330 

By using the PopulationZoneInput:

1. We already have area, so we can skip building up and passing in a reduntant area_km2 vec.
2. We already have a prepared geometry.

And a minor pedantic improvement, by constructing the MetricBuckets before the ContextData, we can avoid initializing with a temporary bogus `Default` value.