### PR TITLE
Contextual layer tweaks

### DIFF
--- a/web/src/AddNeighbourhoodMode.svelte
+++ b/web/src/AddNeighbourhoodMode.svelte
@@ -381,7 +381,9 @@
     </div>
     <hr />
 
-    <button class="secondary" on:click={download}>Export to GeoJSON</button>
+    <button class="secondary" on:click={download}
+      >Export metrics to GeoJSON</button
+    >
   </div>
 
   <div slot="map">

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -98,6 +98,9 @@
 
   let map: Map | null = null;
   $: if (map) {
+    map.keyboard.disableRotation();
+    map.dragRotate.disable();
+    map.touchZoomRotate.disableRotation();
     mapStore.set(map);
   }
 
@@ -224,7 +227,7 @@
             },
           ]}
         >
-          <NavigationControl />
+          <NavigationControl showCompass={false} />
 
           {#if $backend}
             <Control position="top-left">

--- a/web/src/common/ContextLayerButton.svelte
+++ b/web/src/common/ContextLayerButton.svelte
@@ -3,14 +3,23 @@
 
   export let label: string;
   export let show = false;
+  export let onChange: () => void = () => {};
 </script>
 
 <button
   class="context-control"
   style="display: flex; align-items: center; justify-content: leading; gap: 8px; text-align: left;"
-  on:click={() => (show = !show)}
+  on:click={() => {
+    show = !show;
+    onChange();
+  }}
 >
-  <input style="aspect-ratio: 1.0" type="checkbox" bind:checked={show} />
+  <input
+    style="aspect-ratio: 1.0"
+    type="checkbox"
+    bind:checked={show}
+    on:change={onChange}
+  />
   {label}
   {#if $$slots.help}
     <span style="margin-left: auto"

--- a/web/src/common/ModeLink.svelte
+++ b/web/src/common/ModeLink.svelte
@@ -5,14 +5,9 @@
   import { pageTitle } from "./navbar";
 
   export let mode: Mode;
-  export let afterLink: (() => void) | undefined = undefined;
 </script>
 
-<Link
-  on:click={() => {
-    $storedMode = mode;
-    afterLink && afterLink();
-  }}
+<Link on:click={() => ($storedMode = mode)}
   ><slot>
     <span class="page-title">{pageTitle(mode.mode)}</span>
   </slot>

--- a/web/src/context/CBD.svelte
+++ b/web/src/context/CBD.svelte
@@ -9,6 +9,7 @@
     SequentialLegend,
   } from "../common";
   import { assetUrl } from "../stores";
+  import RouteNetwork from "./RouteNetwork.svelte";
 
   // The NPT project bundles together a few layers into one pmtiles file, all
   // related to the Cycling By Design guidance
@@ -39,12 +40,12 @@
   };
 </script>
 
-<ContextLayerButton bind:show={showTraffic} label="Traffic">
+<ContextLayerButton
+  bind:show={showExistingInfra}
+  label="Existing cycling infrastructure"
+>
   <div slot="legend">
-    <SequentialLegend
-      colorScale={traffic.colorScale}
-      labels={{ limits: traffic.limits }}
-    />
+    <QualitativeLegend labelColors={infraTypeColors} />
   </div>
 
   <p slot="help">
@@ -57,7 +58,7 @@
   </p>
 </ContextLayerButton>
 
-<ContextLayerButton bind:show={showLos} label="Level of Service">
+<ContextLayerButton bind:show={showLos} label="Cycling safety Level of Service">
   <div slot="legend">
     <SequentialLegend
       colorScale={Object.values(levelOfServiceColors)}
@@ -76,9 +77,16 @@
   </p>
 </ContextLayerButton>
 
-<ContextLayerButton bind:show={showExistingInfra} label="Cycle infrastructure">
+<RouteNetwork />
+
+<div class="layer-group">Other</div>
+
+<ContextLayerButton bind:show={showTraffic} label="Estimated traffic">
   <div slot="legend">
-    <QualitativeLegend labelColors={infraTypeColors} />
+    <SequentialLegend
+      colorScale={traffic.colorScale}
+      labels={{ limits: traffic.limits }}
+    />
   </div>
 
   <p slot="help">

--- a/web/src/context/ContextualLayers.svelte
+++ b/web/src/context/ContextualLayers.svelte
@@ -13,7 +13,6 @@
   import POIs from "./POIs.svelte";
   import Population from "./Population.svelte";
   import RailwayStations from "./RailwayStations.svelte";
-  import RouteNetwork from "./RouteNetwork.svelte";
   import Stats19 from "./Stats19.svelte";
 
   let expand = false;
@@ -51,15 +50,20 @@
           bind:show={$showExistingFiltersAndTRs}
         />
         {#if $appFocus == "cnt"}
-          <POIs />
+          <div class="layer-group">Metrics</div>
           <Population />
+          <POIs />
+          <Stats19 />
+
+          <div class="layer-group">Public transport integration</div>
           <RailwayStations />
           <BusRoutes />
+
+          <div class="layer-group">Active travel</div>
           <CBD />
-          <RouteNetwork />
-          <Stats19 />
         {/if}
       {/if}
+
       <div class="context-control">
         <span style="font-size: 20px; margin-left: 8px; margin-top: 4px;">
           Basemap
@@ -116,5 +120,11 @@
 
   :global(.pico.contextual-layers .context-control:not(:first-child)) {
     border-top: solid #ddd 1px;
+  }
+
+  :global(.layer-group) {
+    font-size: 1rem;
+    font-weight: bold;
+    padding: 4px;
   }
 </style>

--- a/web/src/context/Population.svelte
+++ b/web/src/context/Population.svelte
@@ -27,7 +27,16 @@
   let showCarOwnership = false;
 </script>
 
-<ContextLayerButton label="SIMD" bind:show={showSIMD}>
+<ContextLayerButton
+  label="SIMD"
+  bind:show={showSIMD}
+  onChange={() => {
+    if (showSIMD) {
+      showDensity = false;
+      showCarOwnership = false;
+    }
+  }}
+>
   <div slot="legend">
     <SequentialLegend
       colorScale={simdColorScale}
@@ -51,7 +60,16 @@
   </p>
 </ContextLayerButton>
 
-<ContextLayerButton label="Population density" bind:show={showDensity}>
+<ContextLayerButton
+  label="Population density"
+  bind:show={showDensity}
+  onChange={() => {
+    if (showDensity) {
+      showSIMD = false;
+      showCarOwnership = false;
+    }
+  }}
+>
   <div slot="legend">
     <SequentialLegend
       colorScale={densityColorScale}
@@ -75,7 +93,16 @@
   </p>
 </ContextLayerButton>
 
-<ContextLayerButton label="Car ownership" bind:show={showCarOwnership}>
+<ContextLayerButton
+  label="Car ownership"
+  bind:show={showCarOwnership}
+  onChange={() => {
+    if (showCarOwnership) {
+      showSIMD = false;
+      showDensity = false;
+    }
+  }}
+>
   <div slot="legend">
     <SequentialLegend
       colorScale={carOwnershipColorScale}

--- a/web/src/context/RouteNetwork.svelte
+++ b/web/src/context/RouteNetwork.svelte
@@ -131,7 +131,7 @@
   }
 </script>
 
-<ContextLayerButton bind:show label="Route network">
+<ContextLayerButton bind:show label="Estimated cycling demand">
   <p slot="help">
     <a href="https://nptscot.github.io/manual/#routenetwork" target="_blank">
       Data from NPT


### PR DESCRIPTION
A few unrelated things:

1) Disable map rotation entirely. It's too easy to do accidentally and unclear how to undo, especially when you tilt. I don't think I've ever seen any reason to use it.

2) Rename a button per Cici's recommendation

3) Rename and group layers based on Cici's recommendation

4) Fix #147, keeping checkbox styling for consistency/simplicity