### PR TITLE
Show simple progress bars for the neighbourhood stats summary

### DIFF
--- a/web/src/common/MetricProgress.svelte
+++ b/web/src/common/MetricProgress.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  export let colorScale;
+  export let limits: number[];
+  export let value: number;
+
+  $: bucketIdx = calculateBucket(limits, value);
+
+  function calculateBucket(limits: number[], value: number): number {
+    // Note the value might exceed the highest limit; it winds up in the last bucket if so
+    let idx = 0;
+    for (let limit of limits.slice(1, -1)) {
+      if (value < limit) {
+        break;
+      }
+      idx++;
+    }
+    return idx;
+  }
+</script>
+
+<div class="colors">
+  {#each colorScale as color, idx}
+    <span class="bucket" class:fits={idx == bucketIdx} style:background={color}
+      >&nbsp;</span
+    >
+  {/each}
+</div>
+
+<style>
+  .colors {
+    display: flex;
+    justify-content: space-around;
+    height: 20px;
+  }
+
+  .colors .bucket {
+    flex: 1;
+  }
+
+  .fits {
+    border: 3px solid red;
+  }
+</style>

--- a/web/src/common/NeighbourhoodBoundarySummary.svelte
+++ b/web/src/common/NeighbourhoodBoundarySummary.svelte
@@ -1,7 +1,19 @@
 <script lang="ts">
   import { prettyPrintPercent } from "../common";
-  import { appFocus } from "../stores";
+  import {
+    carOwnershipColorScale,
+    carOwnershipLimits,
+    combinedColorScale,
+    combinedLimits,
+    poiColorScale,
+    populationDensityColorScale,
+    simdColorScale,
+    simdLimits,
+    stats19ColorScale,
+  } from "../common/colors";
+  import { appFocus, metricBuckets } from "../stores";
   import type { GeneratedBoundaryFeature } from "../wasm";
+  import MetricProgress from "./MetricProgress.svelte";
 
   export let neighbourhoodBoundary: GeneratedBoundaryFeature;
 </script>
@@ -16,7 +28,14 @@
 
   {#if $appFocus == "cnt"}
     <tr>
-      <th>SIMD</th>
+      <th
+        >SIMD
+        <MetricProgress
+          colorScale={simdColorScale}
+          limits={simdLimits}
+          value={neighbourhoodBoundary.properties.simd}
+        />
+      </th>
       <td
         >quintile {1 +
           Math.floor(neighbourhoodBoundary.properties.simd / 20)}</td
@@ -24,7 +43,15 @@
     </tr>
 
     <tr>
-      <th>Population density</th>
+      <th
+        >Population density
+        <MetricProgress
+          colorScale={populationDensityColorScale}
+          limits={$metricBuckets.population_density}
+          value={neighbourhoodBoundary.properties.population /
+            neighbourhoodBoundary.properties.area_km2}
+        />
+      </th>
       <td>
         {Math.round(
           neighbourhoodBoundary.properties.population /
@@ -34,7 +61,16 @@
     </tr>
 
     <tr>
-      <th>Car ownership</th>
+      <th
+        >Car ownership
+        <MetricProgress
+          colorScale={carOwnershipColorScale}
+          limits={carOwnershipLimits}
+          value={(100 *
+            neighbourhoodBoundary.properties.households_with_cars_or_vans) /
+            neighbourhoodBoundary.properties.total_households}
+        />
+      </th>
       <td>
         {prettyPrintPercent(
           neighbourhoodBoundary.properties.households_with_cars_or_vans,
@@ -44,7 +80,15 @@
     </tr>
 
     <tr>
-      <th>POI density</th>
+      <th
+        >POI density
+        <MetricProgress
+          colorScale={poiColorScale}
+          limits={$metricBuckets.poi_density}
+          value={neighbourhoodBoundary.properties.number_pois /
+            neighbourhoodBoundary.properties.area_km2}
+        />
+      </th>
       <td>
         {(
           neighbourhoodBoundary.properties.number_pois /
@@ -54,12 +98,34 @@
     </tr>
 
     <tr>
-      <th>Collision density</th>
+      <th
+        >Collision density
+        <MetricProgress
+          colorScale={stats19ColorScale}
+          limits={$metricBuckets.collision_density}
+          value={neighbourhoodBoundary.properties.number_stats19_collisions /
+            neighbourhoodBoundary.properties.area_km2}
+        />
+      </th>
       <td>
         {(
           neighbourhoodBoundary.properties.number_stats19_collisions /
           neighbourhoodBoundary.properties.area_km2
         ).toFixed(1)} / km²
+      </td>
+    </tr>
+
+    <tr>
+      <th
+        >Overall prioritisation score
+        <MetricProgress
+          colorScale={combinedColorScale}
+          limits={combinedLimits}
+          value={neighbourhoodBoundary.properties.combined_score}
+        />
+      </th>
+      <td>
+        {neighbourhoodBoundary.properties.combined_score} / 5
       </td>
     </tr>
   {/if}

--- a/web/src/common/colors.ts
+++ b/web/src/common/colors.ts
@@ -35,6 +35,7 @@ export let poiColorScale = commonQuintileColorScale.toReversed();
 export let carOwnershipLimits = [0, 20, 40, 60, 80, 100];
 export let carOwnershipColorScale = commonQuintileColorScale;
 
+export let combinedLimits = [0, 1, 2, 3, 4, 5];
 export let combinedColorScale = commonQuintileColorScale.toReversed();
 
 export function bucketize(limits: number[]) {

--- a/web/src/prioritization/PrioritizationSelect.svelte
+++ b/web/src/prioritization/PrioritizationSelect.svelte
@@ -5,6 +5,7 @@
     carOwnershipColorScale,
     carOwnershipLimits,
     combinedColorScale,
+    combinedLimits,
     poiColorScale,
     populationDensityColorScale,
     simdColorScale,
@@ -111,7 +112,7 @@
 {:else if selectedPrioritization == "combined"}
   <SequentialLegend
     colorScale={combinedColorScale}
-    labels={{ limits: [1, 2, 3, 4, 5] }}
+    labels={{ limits: combinedLimits }}
   />
   <div class="sub-labels">
     <span>Least important</span>

--- a/web/src/prioritization/index.ts
+++ b/web/src/prioritization/index.ts
@@ -6,6 +6,7 @@ import {
   carOwnershipColorScale,
   carOwnershipLimits,
   combinedColorScale,
+  combinedLimits,
   poiColorScale,
   populationDensityColorScale,
   simdColorScale,
@@ -64,7 +65,7 @@ export function prioritizationFillColor(
     ),
     combined: makeRamp(
       ["get", "combined_score"],
-      [1, 2, 3, 4, 5],
+      combinedLimits,
       combinedColorScale,
     ),
   }[selectedPrioritization];


### PR DESCRIPTION
FIXES #191.

[Screencast from 25-04-25 17:57:01.webm](https://github.com/user-attachments/assets/e9130ba5-9f62-46b3-a2c0-7af8c659a0b3)

I've gone with a "progress bar" that shows the bucket colors. Cici and Angus liked this enough.

Note car ownership and SIMD are still reversed relative to the other metrics; I'll fix that separately. Showing the colors makes things explicit, in the meantime.