### PR TITLE
summarize scores design tweaks

### DIFF
--- a/web/src/common/MetricProgress.svelte
+++ b/web/src/common/MetricProgress.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { ArrowUp } from "lucide-svelte";
+
   export let colorScale;
   export let limits: number[];
   export let value: number;
@@ -20,24 +22,34 @@
 
 <div class="colors">
   {#each colorScale as color, idx}
-    <span class="bucket" class:fits={idx == bucketIdx} style:background={color}
-      >&nbsp;</span
-    >
+    <div class="bucket" class:selected={idx == bucketIdx}>
+      <div class="bucket-color" style:background={color}></div>
+      <div class="bucket-indicator">
+        <ArrowUp strokeWidth="4px" size="14px" />
+      </div>
+    </div>
   {/each}
 </div>
 
 <style>
   .colors {
     display: flex;
-    justify-content: space-around;
+  }
+
+  .bucket {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .bucket .bucket-color {
     height: 20px;
   }
-
-  .colors .bucket {
-    flex: 1;
+  .bucket .bucket-indicator {
+    display: none;
+    justify-content: center;
   }
-
-  .fits {
-    border: 3px solid red;
+  .bucket.selected .bucket-indicator {
+    display: flex;
   }
 </style>

--- a/web/src/common/colors.ts
+++ b/web/src/common/colors.ts
@@ -35,7 +35,7 @@ export let poiColorScale = commonQuintileColorScale.toReversed();
 export let carOwnershipLimits = [0, 20, 40, 60, 80, 100];
 export let carOwnershipColorScale = commonQuintileColorScale;
 
-export let combinedLimits = [0, 1, 2, 3, 4, 5];
+export let combinedLimits = [1, 2, 3, 4, 5];
 export let combinedColorScale = commonQuintileColorScale.toReversed();
 
 export function bucketize(limits: number[]) {

--- a/web/src/prioritization/PrioritizationSelect.svelte
+++ b/web/src/prioritization/PrioritizationSelect.svelte
@@ -112,7 +112,7 @@
 {:else if selectedPrioritization == "combined"}
   <SequentialLegend
     colorScale={combinedColorScale}
-    labels={{ limits: combinedLimits }}
+    labels={{ buckets: combinedLimits }}
   />
   <div class="sub-labels">
     <span>Least important</span>


### PR DESCRIPTION
Some suggested addendums to #336 

## before

<img width="240" alt="Screenshot 2025-04-25 at 10 40 29" src="https://github.com/user-attachments/assets/04f114f8-a2ce-42fd-bcff-7964f1cf3505" />

## after

1. Show composite score legend as "buckets" rather than sequential.

<img width="508" alt="Screenshot 2025-04-25 at 11 03 22" src="https://github.com/user-attachments/assets/f537c2be-0f3b-4f93-9a80-1f06c8e5ee93" />

---

2. Replaced red border with color-blind friendly indicator. I actually thought it was a black border at first, and I was losing it in the darker blue colors. There was also a minor jitter when moving the border from cell to cell as you add/remove areas. It wasn't noticable if the border moved to an adjacent category, but if you "leapfrogged" over a category (e.g. simd 1 to simd 3) there was a little unfortunate width wiggling.

<img width="459" alt="Screenshot 2025-04-25 at 11 03 13" src="https://github.com/user-attachments/assets/e577f4bc-653f-475b-96b7-ebd6269b82f8" />


