### PR TITLE
Heatmap for collisions

### DIFF
--- a/web/src/common/ContextLayerButton.svelte
+++ b/web/src/common/ContextLayerButton.svelte
@@ -8,7 +8,6 @@
 
 <button
   class="context-control"
-  style="display: flex; align-items: center; justify-content: leading; gap: 8px; text-align: left;"
   on:click={() => {
     show = !show;
     onChange();
@@ -31,6 +30,7 @@
     >
   {/if}
 </button>
+
 {#if show && $$slots.legend}
   <div class="legend">
     <slot name="legend" />
@@ -48,5 +48,13 @@
   .legend {
     color: black;
     padding: 8px;
+  }
+
+  .context-control {
+    display: flex;
+    align-items: center;
+    justify-content: leading;
+    gap: 8px;
+    text-align: left;
   }
 </style>

--- a/web/src/common/zorder.ts
+++ b/web/src/common/zorder.ts
@@ -135,7 +135,8 @@ const layerZorder = [
   "context-bus-routes",
   "context-pois",
   "context-railway-stations",
-  "context-stats19",
+  "context-stats19-heatmap",
+  "context-stats19-points",
 
   dataviz("Road labels"),
   streets("road_label"),

--- a/web/src/context/Stats19.svelte
+++ b/web/src/context/Stats19.svelte
@@ -2,6 +2,7 @@
   import type { ExpressionSpecification } from "maplibre-gl";
   import {
     CircleLayer,
+    HeatmapLayer,
     VectorTileSource,
     type LayerClickInfo,
   } from "svelte-maplibre";
@@ -174,9 +175,23 @@
 </ContextLayerButton>
 
 <VectorTileSource url={`pmtiles://${assetUrl("cnt_layers/stats19.pmtiles")}`}>
-  <CircleLayer
-    {...layerId("context-stats19")}
+  <HeatmapLayer
+    {...layerId("context-stats19-heatmap")}
     sourceLayer="stats19"
+    maxzoom={13}
+    filter={makeFilter(state)}
+    layout={{
+      visibility: show ? "visible" : "none",
+    }}
+    paint={{
+      "heatmap-radius": ["interpolate", ["linear"], ["zoom"], 0, 2, 9, 15],
+    }}
+  />
+
+  <CircleLayer
+    {...layerId("context-stats19-points")}
+    sourceLayer="stats19"
+    minzoom={13}
     paint={{
       "circle-color": makeRamp(
         ["get", "severity"],
@@ -184,17 +199,7 @@
         [fatalColor, seriousColor, slightColor],
       ),
       "circle-opacity": 0.9,
-      "circle-radius": [
-        "interpolate",
-        ["linear"],
-        ["zoom"],
-        1,
-        2,
-        8,
-        3,
-        13,
-        15,
-      ],
+      "circle-radius": 13,
       "circle-stroke-color": "black",
       "circle-stroke-width": 0.1,
     }}


### PR DESCRIPTION
The sea of stats19 dots (with popups!) at low zoom isn't helpful. Switch to a heatmap instead. I've mostly kept maplibre's default heatmap styling, but adjusted the clustering slightly to look decent in both sparse and dense areas. Happy to do more tuning though!

![image](https://github.com/user-attachments/assets/df47ea1e-db36-4ca9-a6e2-9806560a9e55)
![image](https://github.com/user-attachments/assets/73fcb3d8-609e-40de-843f-fa861daae63e)

(Videos are hitting the 10MB limit too quickly, with so much on the screen)