### PR TITLE
Cleanly handle one error case when drawing boundaries

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -192,8 +192,7 @@ impl LTN {
             .map(|feature| {
                 let mut polygon = Polygon::try_from(feature).map_err(err_to_js)?;
                 self.map.mercator.to_mercator_in_place(&mut polygon);
-                make_polygon_valid(&mut polygon);
-                Ok(polygon)
+                make_polygon_valid(&polygon).map_err(err_to_js)
             })
             .collect::<Result<Vec<Polygon>, JsValue>>()?;
         let merged_boundary = self

--- a/backend/src/neighbourhood.rs
+++ b/backend/src/neighbourhood.rs
@@ -154,7 +154,7 @@ impl NeighbourhoodDefinition {
         let mut neighbourhood_definition: Self = geojson::de::from_feature(feature)?;
         map.mercator
             .to_mercator_in_place(&mut neighbourhood_definition.geometry);
-        neighbourhood_definition.geometry = make_polygon_valid(&neighbourhood_definition.geometry);
+        neighbourhood_definition.geometry = make_polygon_valid(&neighbourhood_definition.geometry)?;
         Ok(neighbourhood_definition)
     }
 }


### PR DESCRIPTION
FIXES #257 
[Screencast from 29-04-25 09:58:06.webm](https://github.com/user-attachments/assets/bb0f61b3-0ccd-4a8a-b4ee-f3122e71f23f)

The behavior in debug mode feels correct to me here. The 3 points don't form a valid area for this odd case, because they just double back to try and connect. It feels intuitive to me to have the left sidebar reflect that I haven't made a valid area yet.