### PR TITLE
Add an area prioritization metric

### DIFF
--- a/web/src/AddNeighbourhoodMode.svelte
+++ b/web/src/AddNeighbourhoodMode.svelte
@@ -429,7 +429,7 @@
         >
           {#if selectedPrioritization != "simd"}
             <Popup openOn="hover" let:props>
-              {#if selectedPrioritization == "none"}
+              {#if selectedPrioritization == "none" || selectedPrioritization == "area"}
                 <b>Area:</b>
                 {props.area_km2.toFixed(1)} km²
               {:else if selectedPrioritization == "car_ownership"}

--- a/web/src/common/NeighbourhoodBoundarySummary.svelte
+++ b/web/src/common/NeighbourhoodBoundarySummary.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { prettyPrintPercent } from "../common";
   import {
+    areaColorScale,
+    areaLimits,
     carOwnershipColorScale,
     carOwnershipLimits,
     combinedColorScale,
@@ -20,7 +22,14 @@
 
 <table>
   <tr>
-    <th>Area</th>
+    <th
+      >Area
+      <MetricProgress
+        colorScale={areaColorScale}
+        limits={areaLimits}
+        value={neighbourhoodBoundary.properties.area_km2}
+      />
+    </th>
     <td>
       {neighbourhoodBoundary.properties.area_km2.toFixed(1)} km²
     </td>

--- a/web/src/common/colors.ts
+++ b/web/src/common/colors.ts
@@ -26,8 +26,15 @@ export let populationDensityColorScale = commonQuintileColorScale.toReversed();
 
 export let demandColorScale = commonQuintileColorScale.toReversed();
 
-export let areaLimits = [0.0, 0.3, 0.6, 1.0, 1.5, 2.0];
-export let areaColorScale = commonQuintileColorScale.toReversed();
+// From page 7 of https://content.tfl.gov.uk/lsp-app-six-b-strategic-neighbourhoods-analysis-v1.pdf, except removing the smallest bucket to make five
+export let areaLimits = [0.0, 0.25, 0.5, 1, 1.5, 2.0];
+export let areaColorScale = [
+  "#F8E4AF",
+  "#9ECC4E",
+  "#00BB44",
+  "#4ACD8B",
+  "#B9E9E9",
+];
 
 export let stats19ColorScale = commonQuintileColorScale.toReversed();
 

--- a/web/src/prioritization/PrioritizationSelect.svelte
+++ b/web/src/prioritization/PrioritizationSelect.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { SequentialLegend } from "svelte-utils";
   import {
+    areaColorScale,
+    areaLimits,
     bucketize,
     carOwnershipColorScale,
     carOwnershipLimits,
@@ -22,7 +24,9 @@
       "prioritisationMetric",
     );
 
-    if (currentURLParam == "population_density") {
+    if (currentURLParam == "area") {
+      selectedPrioritization = "area";
+    } else if (currentURLParam == "population_density") {
       selectedPrioritization = "population_density";
     } else if (currentURLParam == "simd") {
       selectedPrioritization = "simd";
@@ -59,6 +63,7 @@
   >
   <select id="prioritization-selection" bind:value={selectedPrioritization}>
     <option value="none">None</option>
+    <option value="area">Area</option>
     <option value="simd">SIMD</option>
     <option value="population_density">Population density</option>
     <option value="car_ownership">Car ownership</option>
@@ -68,7 +73,17 @@
   </select>
 </div>
 
-{#if selectedPrioritization == "population_density"}
+{#if selectedPrioritization == "area"}
+  <SequentialLegend
+    colorScale={areaColorScale}
+    labels={{ limits: areaLimits }}
+  />
+  <div class="sub-labels">
+    <span />
+    <span>km²</span>
+    <span />
+  </div>
+{:else if selectedPrioritization == "population_density"}
   <SequentialLegend
     colorScale={populationDensityColorScale}
     labels={{ limits: $metricBuckets.population_density }}

--- a/web/src/prioritization/index.ts
+++ b/web/src/prioritization/index.ts
@@ -19,6 +19,7 @@ export { default as PrioritizationSelect } from "./PrioritizationSelect.svelte";
 
 export type Prioritization =
   | "none"
+  | "area"
   | "car_ownership"
   | "population_density"
   | "pois"


### PR DESCRIPTION
FIXES #193, at least in spirit.

We decided to include an area metric after all, but not to include it in the combined score. We're using limits and colors from page 7 of https://content.tfl.gov.uk/lsp-app-six-b-strategic-neighbourhoods-analysis-v1.pdf, because there's no Scottish guidance.

![image](https://github.com/user-attachments/assets/ab9046d9-7685-4c6b-a0ff-8751a199e495)
