### PR TITLE
Enhance the initial loading screen to show download progress and sepa…

### DIFF
--- a/web/src/AddNeighbourhoodMode.svelte
+++ b/web/src/AddNeighbourhoodMode.svelte
@@ -20,6 +20,7 @@
     ModeLink,
     pageTitle,
     prettyPrintPercent,
+    refreshLoadingScreen,
   } from "./common";
   import AreaControls from "./common/draw_area/AreaControls.svelte";
   import { type Waypoint } from "./common/draw_area/stores";
@@ -88,17 +89,7 @@
   }
 
   onMount(async () => {
-    // Make sure the loading indicator has rendered before we generate boundaries.
-    //
-    // NOTE: I thought this is what `svelte.tick` was for, but it doesn't suffice.
-    //     await tick();
-    await new Promise((resolve) => {
-      requestAnimationFrame(() => {
-        // Waiting for one frame also doesn't seem to be enough, so we wait for two. *shrug*
-        requestAnimationFrame(resolve);
-      });
-    });
-
+    await refreshLoadingScreen();
     generatedBoundaries = $backend!.generatedBoundaries();
     loading = "";
   });
@@ -237,6 +228,7 @@
 </script>
 
 <Loading {loading} />
+
 <SplitComponent>
   <div slot="top">
     <nav aria-label="breadcrumb">

--- a/web/src/CntChooseArea.svelte
+++ b/web/src/CntChooseArea.svelte
@@ -14,8 +14,6 @@
   import { mode, projectStorage } from "./stores";
   import { loadProject } from "./title/loader";
 
-  export let activityIndicatorText: string;
-
   let gj: FeatureCollection<
     Polygon | MultiPolygon,
     { kind: "LAD"; name: string }
@@ -65,7 +63,6 @@
         );
         continue;
       }
-      activityIndicatorText = `Loading pre-clipped OSM area ${prettyPrintStudyAreaName(studyAreaName)}`;
       try {
         let projectID = $projectStorage.createEmptyProject(
           projectName,
@@ -77,7 +74,6 @@
       } catch (e) {
         window.alert(e);
       }
-      activityIndicatorText = "";
     }
   }
 </script>

--- a/web/src/ImpactDetailMode.svelte
+++ b/web/src/ImpactDetailMode.svelte
@@ -13,6 +13,7 @@
     ModeLink,
     pageTitle,
     PrevNext,
+    refreshLoadingScreen,
   } from "./common";
   import { ModalFilterLayer } from "./layers";
   import { backend, fastSample, mode } from "./stores";
@@ -30,13 +31,7 @@
 
   let loading = "Finding changes to this road";
   onMount(async () => {
-    // Render the loading screen before starting the calculation. Unsure why Svelte tick() or one frame doesn't work.
-    await new Promise((resolve) => {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(resolve);
-      });
-    });
-
+    await refreshLoadingScreen();
     routes = $backend!.getImpactsOnRoad(props.id, $fastSample);
     loading = "";
     if (routes.length == 0) {

--- a/web/src/PredictImpactMode.svelte
+++ b/web/src/PredictImpactMode.svelte
@@ -5,7 +5,13 @@
   import { Popup } from "svelte-utils/map";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
   import BackButton from "./BackButton.svelte";
-  import { layerId, Loading, ModeLink, pageTitle } from "./common";
+  import {
+    layerId,
+    Loading,
+    ModeLink,
+    pageTitle,
+    refreshLoadingScreen,
+  } from "./common";
   import { ModalFilterLayer } from "./layers";
   import { backend, fastSample, minImpactCount, mode } from "./stores";
   import type { Impact } from "./wasm";
@@ -34,13 +40,7 @@
 
   async function recalculate(fastSample: boolean) {
     loading = "Calculating impact";
-    // Render the loading screen before starting the calculation. Unsure why Svelte tick() or one frame doesn't work.
-    await new Promise((resolve) => {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(resolve);
-      });
-    });
-
+    await refreshLoadingScreen();
     impactGj = $backend!.predictImpact(fastSample);
     loading = "";
   }

--- a/web/src/common/Loading.svelte
+++ b/web/src/common/Loading.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  export let loading;
-  export let progress = null;
+  export let loading: string;
+  export let progress: number | null = null;
 
   let startTime: number | undefined = undefined;
   let taskName: string | undefined = undefined;
@@ -20,13 +20,19 @@
 
 {#if loading}
   <div class="cover">
-    {loading}
+    <div class="background">
+      {loading}
 
-    {#if progress != null}
-      <div>
-        <progress value={progress} style:width="100%" />
-      </div>
-    {/if}
+      {#if progress != null}
+        <div>
+          {#if progress == 100}
+            <progress style:width="100%" />
+          {:else}
+            <progress value={progress} max="100" style:width="100%" />
+          {/if}
+        </div>
+      {/if}
+    </div>
   </div>
 {/if}
 
@@ -46,5 +52,10 @@
 
     color: white;
     font-size: 32px;
+  }
+
+  .background {
+    background: grey;
+    padding: 16px;
   }
 </style>

--- a/web/src/common/index.ts
+++ b/web/src/common/index.ts
@@ -125,7 +125,8 @@ export function mapMetersToPixels(
   ];
 }
 
-// Fetch a URL, throwing if the HTTP response isn't OK.
+// Fetch a URL, throwing if the HTTP response isn't OK. If you want progress
+// updates, use fetchWithProgress.
 export async function safeFetch(url: string): Promise<Response> {
   let response = await fetch(url);
   if (!response.ok) {
@@ -144,4 +145,15 @@ export function stripPrefix(value: string, prefix: string): string {
 
 export function stripSuffix(value: string, suffix: string): string {
   return value.endsWith(suffix) ? value.slice(0, -suffix.length) : value;
+}
+
+// This is a replacement for `svelte.tick`, which doesn't seem to work for some
+// reason. Wait for two frames, to give the Loading component a chance to
+// update, before doing someting blocking on the UI thread.
+export async function refreshLoadingScreen(): Promise<void> {
+  await new Promise((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(resolve);
+    });
+  });
 }

--- a/web/src/title/LoadSavedProject.svelte
+++ b/web/src/title/LoadSavedProject.svelte
@@ -4,13 +4,10 @@
   import { database, mode, type AppFocus } from "../stores";
   import { loadProject } from "./loader";
 
-  export let loading: string;
-
   let fileInput: HTMLInputElement;
 
   async function loadFile(e: Event) {
     let filename = fileInput.files![0].name;
-    loading = `Loading from file ${filename}`;
 
     let contents = await fileInput.files![0].text();
     let gj = JSON.parse(contents);
@@ -66,7 +63,6 @@
     let projectID = projectStorage.createProject(gj);
     await loadProject(projectID);
     $mode = { mode: "pick-neighbourhood" };
-    loading = "";
   }
 </script>
 

--- a/web/src/title/NewProjectMode.svelte
+++ b/web/src/title/NewProjectMode.svelte
@@ -15,7 +15,12 @@
     projectStorage,
   } from "../stores";
   import { Backend } from "../wasm";
-  import { afterProjectLoaded, loadProject } from "./loader";
+  import {
+    afterProjectLoaded,
+    loadingMessage,
+    loadingProgress,
+    loadProject,
+  } from "./loader";
 
   let newProjectName = "";
   let example: string | null = null;
@@ -70,12 +75,13 @@
       window.alert(`Couldn't create project: ${err}`);
       return;
     }
-    loading = `Loading pre-clipped OSM area ${example}`;
     await loadProject(projectID);
     $mode = { mode: "add-neighbourhood" };
-    loading = "";
   }
 </script>
+
+<Loading {loading} progress={100} />
+<Loading loading={$loadingMessage} progress={$loadingProgress} />
 
 <SplitComponent>
   <div slot="top">
@@ -98,8 +104,6 @@
     </div>
 
     {#if newProjectName}
-      <Loading {loading} />
-
       <label>
         Load a built-in area:
         <select bind:value={example} on:change={() => loadExample()}>

--- a/web/src/title/TitleMode.svelte
+++ b/web/src/title/TitleMode.svelte
@@ -21,12 +21,10 @@
     mode,
     projectStorage,
   } from "../stores";
-  import { loadProject } from "./loader";
+  import { loadingMessage, loadingProgress, loadProject } from "./loader";
   import LoadSavedProject from "./LoadSavedProject.svelte";
 
   export let wasmReady: boolean;
-
-  let loading = "";
 
   // When other modes reset here, they can't clear state without a race condition
   {
@@ -66,12 +64,7 @@
   function loadProjectFromUrlParam(projectIDParam: string) {
     let projectID = projectIDParam as ProjectID;
     try {
-      let projectName = $projectStorage.projectName(projectID);
-      if (!projectName) {
-        console.error(`Project ${projectID} from URL not found`);
-        return;
-      }
-      projectLoadingScreen(projectID, projectName);
+      openProject(projectID);
     } catch {
       console.error(`Error trying to fetch project from URL: ${projectID}`);
     }
@@ -103,18 +96,13 @@
     }
   }
 
-  async function projectLoadingScreen(
-    projectID: ProjectID,
-    projectName: string,
-  ) {
-    loading = `Loading project ${projectName}`;
+  async function openProject(projectID: ProjectID) {
     await loadProject(projectID);
     $mode = { mode: "pick-neighbourhood" };
-    loading = "";
   }
 </script>
 
-<Loading {loading} />
+<Loading loading={$loadingMessage} progress={$loadingProgress} />
 
 <SplitComponent>
   <div slot="top">
@@ -137,10 +125,7 @@
               {#each projects as { projectID, projectName }}
                 <li class="actionable-cell">
                   <h3>
-                    <Link
-                      on:click={() =>
-                        projectLoadingScreen(projectID, projectName)}
-                    >
+                    <Link on:click={() => openProject(projectID)}>
                       {projectName}
                     </Link>
                   </h3>
@@ -180,9 +165,9 @@
           New project
         </button>
       {:else if $appFocus == "cnt"}
-        <CntChooseArea bind:activityIndicatorText={loading} />
+        <CntChooseArea />
       {/if}
-      <LoadSavedProject bind:loading />
+      <LoadSavedProject />
     {:else}
       <p>Waiting for MapLibre and WASM to load...</p>
     {/if}


### PR DESCRIPTION
…rately indicate parsing/setup

Part of #311. Give the user more info about what's happening during initial setup, for all cases of CNT/global mode, downloading from overpass vs a pre-clipped file, downloading vs CPU-bound setup.

It's a nicer view on slow internet, but here's one example:

[Screencast from 08-05-25 14:18:03.webm](https://github.com/user-attachments/assets/5d92255c-f15a-4a91-871e-f497ef0db5b9)
