### PR TITLE
If a user loads an empty project or deletes all neighbourhoods, don't

### DIFF
--- a/web/src/PickNeighbourhoodMode.svelte
+++ b/web/src/PickNeighbourhoodMode.svelte
@@ -44,6 +44,12 @@
   $: neighbourhoods = $backend!.getAllNeighbourhoods();
   $: edits = countEdits(neighbourhoods);
 
+  // If a user loads an empty project or deletes all neighbourhoods, don't show
+  // them an empty pick screen
+  $: if (neighbourhoods.features.length == 0) {
+    $mode = { mode: "add-neighbourhood" };
+  }
+
   let selectedPrioritization: Prioritization =
     $appFocus == "cnt" ? "combined" : "none";
   let hoveredNeighbourhoodFromList: string | null = null;


### PR DESCRIPTION
show them an empty pick screen

We've had a few bits of confused feedback from people loading an empty project and not understanding what to do (despite the primary "add neighbourhood" button. So just forcibly prevent people from winding up on this screen without anything defined.