### PR TITLE
Rebrand the tool for CNT

### DIFF
--- a/web/src/About.svelte
+++ b/web/src/About.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
   import { Modal } from "svelte-utils";
-  import { showAbout } from "./stores";
+  import { appFocus, showAbout } from "./stores";
 </script>
 
 <Modal bind:show={$showAbout}>
-  <h1>The low-traffic neighbourhood (LTN) tool, v2</h1>
+  {#if $appFocus == "cnt"}
+    <h1>The Connected Neighbourhoods Tool</h1>
+  {:else}
+    <h1>The Low-Traffic Neighbourhood (LTN) tool, v2</h1>
+  {/if}
 
   <p>
     This is the second version of the A/B Street LTN tool, <a

--- a/web/src/title/TitleMode.svelte
+++ b/web/src/title/TitleMode.svelte
@@ -126,13 +126,17 @@
   </div>
   <div slot="sidebar">
     {#if $map && wasmReady}
+      {#if $appFocus == "cnt"}
+        <h1>The Connected Neighbourhoods Tool</h1>
+      {/if}
+
       {#if studyAreas.length > 0}
-        <h1>Your projects</h1>
+        <h2>Your projects</h2>
         <div class="project-list">
           {#each studyAreas as [studyAreaName, projects]}
-            <h2 class="study-area-name">
+            <h3 class="study-area-name">
               {prettyPrintStudyAreaName(studyAreaName)}
-            </h2>
+            </h3>
             <ul class="navigable-list">
               {#each projects as { projectID, projectName }}
                 <li class="actionable-cell">
@@ -174,7 +178,7 @@
         </div>
       {/if}
 
-      <h1>Start a new project</h1>
+      <h2>Start a new project</h2>
       {#if $appFocus == "global"}
         <button on:click={() => ($mode = { mode: "new-project" })}>
           New project


### PR DESCRIPTION
More clear branding has been requested, so in CNT mode:
![image](https://github.com/user-attachments/assets/5517838a-2843-41e1-8270-cb70109e849f)
![image](https://github.com/user-attachments/assets/bc08d24e-3177-497a-8681-b3e5b4f550c0)
