### PR TITLE
Handle edge cases with no main roads

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -400,6 +400,14 @@ impl LTN {
         self.after_main_road_edit()
     }
 
+    #[wasm_bindgen(js_name = eraseAllMainRoads)]
+    pub fn erase_all_main_roads(&mut self) -> Result<(), JsValue> {
+        self.map
+            .erase_all_main_roads(self.neighbourhood.as_ref().unwrap());
+        self.after_edit();
+        self.after_main_road_edit()
+    }
+
     pub fn undo(&mut self) -> Result<(), JsValue> {
         let maybe_cmd = self.map.undo();
         self.after_cmd(maybe_cmd)

--- a/backend/src/map_model.rs
+++ b/backend/src/map_model.rs
@@ -574,6 +574,21 @@ impl MapModel {
         self.after_edited();
     }
 
+    pub fn erase_all_main_roads(&mut self, neighbourhood: &Neighbourhood) {
+        let cmds = neighbourhood
+            .main_roads
+            .iter()
+            .map(|r| Command::SetMainRoad(*r, false))
+            .collect::<Vec<_>>();
+        if cmds.is_empty() {
+            return;
+        }
+        let undo_cmd = self.do_edit(Command::Multiple(cmds));
+        self.undo_stack.push(undo_cmd);
+        self.redo_stack.clear();
+        self.after_edited();
+    }
+
     // Returns the command to undo this one
     fn do_edit(&mut self, cmd: Command) -> Command {
         match cmd {

--- a/backend/src/neighbourhood.rs
+++ b/backend/src/neighbourhood.rs
@@ -251,13 +251,6 @@ impl Neighbourhood {
             bail!("No roads inside the boundary");
         }
 
-        if main_roads.is_empty() {
-            // App breaks without main roads: without main roads, there's only one cell,
-            // so it counts as disconnected (because it doesn't touch a border intersection), and
-            // thus we can't calculate shortcuts through it without those intersections.
-            bail!("No main roads");
-        }
-
         let t3 = Instant::now();
 
         if true {

--- a/backend/src/render_cells.rs
+++ b/backend/src/render_cells.rs
@@ -125,7 +125,8 @@ impl RenderCells {
 
         // Color some special cells
         for (idx, cell) in cells.iter().enumerate() {
-            if cell.is_disconnected() {
+            // If there's only one cell, it's not disconnected -- there are likely no main roads
+            if cell.is_disconnected() && cells.len() > 1 {
                 cell_colors[idx] = Color::Disconnected;
             }
         }

--- a/web/src/edit/NeighbourhoodMode.svelte
+++ b/web/src/edit/NeighbourhoodMode.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import type { Feature, FeatureCollection, LineString } from "geojson";
-  import { Eraser, Paintbrush, Pointer, Redo, Undo } from "lucide-svelte";
+  import {
+    Eraser,
+    Paintbrush,
+    Pointer,
+    Redo,
+    Trash2,
+    Undo,
+  } from "lucide-svelte";
   import type { LngLat, MapMouseEvent } from "maplibre-gl";
   import { onDestroy, onMount } from "svelte";
   import {
@@ -301,6 +308,11 @@
     }
   }
 
+  function eraseAllMainRoads() {
+    $backend!.eraseAllMainRoads();
+    $mutationCounter++;
+  }
+
   let shortcutDescriptionText =
     "Shortcuts are routes from one main road to another, which cut through the neighborhood's interior.";
   let cellsDescriptionText =
@@ -561,6 +573,12 @@
             <div style="display: flex; align-items: center; gap: 8px;">
               <Eraser />
               <span>Erase main classification</span>
+            </div>
+          </button>
+          <button class:outline={true} on:click={eraseAllMainRoads}>
+            <div style="display: flex; align-items: center; gap: 8px;">
+              <Trash2 />
+              <span>Erase all main roads</span>
             </div>
           </button>
         </div>

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -339,6 +339,10 @@ export class Backend {
       return null;
     }
   }
+
+  eraseAllMainRoads() {
+    this.inner.eraseAllMainRoads();
+  }
 }
 
 export type Impact = FeatureCollection<


### PR DESCRIPTION
It's totally possible to manually draw an area that has no main roads at all. Previously there was a popup error, but with this PR, it's now possible, but the result is pretty boring, because there are no shortcuts.
![image](https://github.com/user-attachments/assets/d990125c-edfd-47f5-be35-2e92e2b59a65)

The real use of this is with a new button to erase all main roads at once. If you're working on a circulation plan in a huge area like this, using the eraser tool or manually clicking all of the main roads on the inside is really, really tedious:

![image](https://github.com/user-attachments/assets/6fc17445-22e4-4a36-8e1a-e551fcc6632f)

It's easier in this case to just blank out all the main roads, then draw only the main roads around the outside, and any on the inside that should retain through-traffic. We can call out this special use case in the user guide.