### PR TITLE
Reorganize CNT asset storage and gzip most files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,13 @@
 *.swp
 target/
 node_modules/
+
 data_prep/scotland/tmp
 data_prep/scotland/input
-data_prep/scotland/demand
-data_prep/scotland/out_layers
-data_prep/scotland/prioritization
-# Local symlinks to avoid hitting od2net.org
+data_prep/scotland/od.csv
+data_prep/scotland/zones.geojson
+
+# Local symlinks to avoid hitting od2net.org and cnt.scot
 web/public/severance_pbfs
 web/public/boundaries
-web/public/cnt_osm
-web/public/cnt_boundaries
-web/public/cnt_demand
-web/public/cnt_layers
-web/public/cnt_prioritization
+web/public/cnt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,10 @@
 version = 4
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -80,6 +80,7 @@ dependencies = [
  "contour",
  "criterion",
  "fast_paths",
+ "flate2",
  "geo",
  "geojson",
  "i_overlay",
@@ -418,9 +419,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -731,11 +732,11 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ Custom areas imported by the user are always retrieved from the Overpass API,
 with the latest OSM data. For speed and for deterministic tests, there are also
 "built-in" study areas, consisting of pre-clipped osm.pbf files that do not
 automatically use the latest OSM data. These are manually managed and hosted by
-Dustin on assets.od2net.org.
+Dustin on assets.od2net.org and assets.cnt.scot.
 
-If you're developing locally, you can avoid hitting od2net.org by running
-`bin/download-local-dev-data.sh` to download some pre-clipped application
-data locally, then the Svelte app will load from localhost, not od2net.org.
+If you're developing locally, you can cache assets locally by running
+`bin/download-local-dev-data.sh`.
 
 ### Tests
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -13,6 +13,7 @@ console_error_panic_hook = "0.1.6"
 console_log = "1.0.0"
 contour = "0.12.0"
 fast_paths = "1.0.0"
+flate2 = "1.1.1"
 geo.workspace = true
 geojson.workspace = true
 itertools = "0.14.0"
@@ -35,9 +36,8 @@ web-sys = { version = "0.3.64", features = ["console"] }
 web-time = "1.0.0"
 
 [dev-dependencies]
-criterion = "0.5.1"
 approx = "0.5.1"
-
+criterion = "0.5.1"
 
 [[bench]]
 name = "boundary_stats"

--- a/bin/download-local-dev-data.sh
+++ b/bin/download-local-dev-data.sh
@@ -22,12 +22,12 @@ cd "${APP_ROOT}/web/public"
 
 # Scotland specific data
 jq '.features[] | .properties.kind + "_" + .properties.name' ../../data_prep/scotland/boundaries.geojson | sed 's/"//g' | while read x; do
-    download_to_subdir cnt_boundaries "https://assets.od2net.org/cnt_boundaries/$x.geojson"
-    download_to_subdir cnt_osm "https://assets.od2net.org/cnt_osm/$x.osm.pbf"
-    download_to_subdir cnt_demand "https://assets.od2net.org/cnt_demand/demand_$x.bin"
-    download_to_subdir cnt_prioritization "https://assets.od2net.org/cnt_prioritization/context_$x.bin"
+    download_to_subdir cnt/boundaries "https://assets.cnt.scot/prod/boundaries/$x.geojson"
+    download_to_subdir cnt/osm "https://assets.cnt.scot/prod/osm/$x.osm.pbf"
+    download_to_subdir cnt/demand "https://assets.cnt.scot/prod/demand/$x.bin"
+    download_to_subdir cnt/prioritization "https://assets.cnt.scot/prod/prioritization/$x.bin"
 done
 
 for x in bus_routes.pmtiles cbd.pmtiles population.pmtiles railways.geojson route_network.pmtiles stats19.pmtiles; do
-    download_to_subdir cnt_layers https://assets.od2net.org/cnt_layers/$x
+    download_to_subdir cnt/layers https://assets.cnt.scot/prod/layers/$x
 done

--- a/data_prep/.gitignore
+++ b/data_prep/.gitignore
@@ -1,3 +1,0 @@
-od.csv
-zones.geojson
-out/

--- a/data_prep/scotland/README.md
+++ b/data_prep/scotland/README.md
@@ -12,7 +12,7 @@ unzip SG_IntermediateZoneBdry_2011.zip
 ogr2ogr zones.geojson -t_srs EPSG:4326 -nlt PROMOTE_TO_MULTI SG_IntermediateZone_Bdry_2011.shp -sql 'SELECT InterZone as name FROM SG_IntermediateZone_Bdry_2011'
 rm -f SG_IntermediateZone_Bdry_2011* SG_IntermediateZoneBdry_2011.zip
 
-mkdir -p demand
+mkdir -p ../../web/public/cnt/demand ../../web/public/cnt/prioritization
 cargo run --release --bin generate_od
 cargo run --release --bin generate_prioritization
 ```

--- a/data_prep/scotland/build_all_areas.sh
+++ b/data_prep/scotland/build_all_areas.sh
@@ -27,12 +27,16 @@ function split_osm {
           time osmium extract -v -c $batch ../scotland-latest.osm.pbf
         done
 
-        cd ../..
+        # Gzip everything
+        cd ../osm_out
+        for x in *; do
+          gzip "$x"
+        done
 }
 
 split_osm
 
-echo "For maintainer only:"
-echo "  mv tmp/osm_out/* ~/cloudflare_sync/cnt_osm/"
-echo "  cp tmp/osmium_inputs/*geojson ~/cloudflare_sync/cnt_boundaries/"
-echo "And then upload"
+echo "To use these files:"
+echo "  mkdir -p ../../web/public/cnt/osm ../../web/public/cnt/boundaries"
+echo "  mv tmp/osm_out/* ../../web/public/cnt/osm/"
+echo "  mv tmp/osmium_inputs/*geojson ../../web/public/cnt/boundaries/"

--- a/data_prep/scotland/geojson_to_osmium_extracts.py
+++ b/data_prep/scotland/geojson_to_osmium_extracts.py
@@ -21,13 +21,11 @@ def main():
     )
     parser.add_argument(
         "--batch_size",
-        default=10,
         help="How many areas to extract in each osmium run. Too many will eat your RAM.",
         type=int,
     )
     parser.add_argument(
         "--output_dir",
-        default="./",
         help="Where to write the .osm output files",
         type=str,
     )

--- a/data_prep/scotland/get_reference_layers.sh
+++ b/data_prep/scotland/get_reference_layers.sh
@@ -2,7 +2,7 @@
 
 set -e
 set -x
-OUT=out_layers
+OUT=../../web/public/cnt/layers
 mkdir -p $OUT
 
 function route_network {
@@ -245,9 +245,3 @@ download_to_subdir() {
 #bus_routes
 #population
 #stats19
-
-echo "Now, copy any layers you want for your local development:"
-echo "  cp $OUT/* ../../web/public/cnt_layers/"
-echo "For maintainer only:"
-echo "  mv $OUT/* ~/cloudflare_sync/cnt_layers/"
-echo "And then upload"

--- a/data_prep/scotland/src/bin/generate_od.rs
+++ b/data_prep/scotland/src/bin/generate_od.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::process::Command;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use geo::{Intersects, MultiPolygon};
 use serde::Deserialize;
 use utils::Mercator;
@@ -44,13 +45,21 @@ fn main() -> Result<()> {
             desire_lines: subset_desire_lines,
             cached_zone_roads: vec![],
         };
-        let path = format!("demand/demand_{}_{}.bin", study_area.kind, study_area.name);
+        let path = format!(
+            "../../web/public/cnt/demand/{}_{}.bin",
+            study_area.kind, study_area.name
+        );
         println!(
             "Writing {path} with {} matching zones and {} desire lines",
             demand.zones.len(),
             demand.desire_lines.len()
         );
-        std::fs::write(path, bincode::serialize(&demand)?)?;
+        std::fs::write(&path, bincode::serialize(&demand)?)?;
+
+        println!("Running: gzip {path}");
+        if !Command::new("gzip").arg(&path).status()?.success() {
+            bail!("`gzip {path}` failed");
+        }
     }
 
     Ok(())

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -80,7 +80,7 @@
       let resp = await fetch("/severance_pbfs/areas.json");
       if (resp.ok) {
         $useLocalVite = true;
-        console.log("Using local cache, not od2net.org");
+        console.log("Using local asset files");
       }
     } catch (err) {}
 

--- a/web/src/context/BusRoutes.svelte
+++ b/web/src/context/BusRoutes.svelte
@@ -19,7 +19,7 @@
 </ContextLayerButton>
 
 <VectorTileSource
-  url={`pmtiles://${assetUrl("cnt_layers/bus_routes.pmtiles")}`}
+  url={`pmtiles://${assetUrl("cnt/layers/bus_routes.pmtiles")}`}
 >
   <LineLayer
     {...layerId("context-bus-routes")}

--- a/web/src/context/CBD.svelte
+++ b/web/src/context/CBD.svelte
@@ -94,7 +94,7 @@
   </p>
 </ContextLayerButton>
 
-<VectorTileSource url={`pmtiles://${assetUrl("cnt_layers/cbd.pmtiles")}`}>
+<VectorTileSource url={`pmtiles://${assetUrl("cnt/layers/cbd.pmtiles")}`}>
   <LineLayer
     {...layerId("context-traffic")}
     sourceLayer="cbd_layer"

--- a/web/src/context/Population.svelte
+++ b/web/src/context/Population.svelte
@@ -119,7 +119,7 @@
 </ContextLayerButton>
 
 <VectorTileSource
-  url={`pmtiles://${assetUrl("cnt_layers/population.pmtiles")}`}
+  url={`pmtiles://${assetUrl("cnt/layers/population.pmtiles")}`}
 >
   <FillLayer
     {...layerId("context-simd")}

--- a/web/src/context/RailwayStations.svelte
+++ b/web/src/context/RailwayStations.svelte
@@ -25,7 +25,7 @@
   </p>
 </ContextLayerButton>
 
-<GeoJSON data={assetUrl("cnt_layers/railways.geojson")} generateId>
+<GeoJSON data={assetUrl("cnt/layers/railways.geojson")} generateId>
   <SymbolLayer
     {...layerId("context-railway-stations")}
     layout={{

--- a/web/src/context/RouteNetwork.svelte
+++ b/web/src/context/RouteNetwork.svelte
@@ -178,7 +178,7 @@
 </ContextLayerButton>
 
 <VectorTileSource
-  url={`pmtiles://${assetUrl("cnt_layers/route_network.pmtiles")}`}
+  url={`pmtiles://${assetUrl("cnt/layers/route_network.pmtiles")}`}
 >
   <LineLayer
     {...layerId("context-route-network")}

--- a/web/src/context/Stats19.svelte
+++ b/web/src/context/Stats19.svelte
@@ -175,7 +175,7 @@
   </div>
 </ContextLayerButton>
 
-<VectorTileSource url={`pmtiles://${assetUrl("cnt_layers/stats19.pmtiles")}`}>
+<VectorTileSource url={`pmtiles://${assetUrl("cnt/layers/stats19.pmtiles")}`}>
   <HeatmapLayer
     {...layerId("context-stats19-heatmap")}
     sourceLayer="stats19"

--- a/web/src/stores.ts
+++ b/web/src/stores.ts
@@ -8,6 +8,7 @@ import {
   type Readable,
   type Writable,
 } from "svelte/store";
+import { stripPrefix } from "./common";
 import {
   Database,
   ProjectStorage,
@@ -149,7 +150,15 @@ export function saveCurrentProject() {
 export let useLocalVite: Writable<boolean> = writable(false);
 
 export function assetUrl(path: string): string {
-  return get(useLocalVite) ? `/${path}` : `https://assets.od2net.org/${path}`;
+  if (get(useLocalVite)) {
+    return `/${path}`;
+  }
+
+  if (path.startsWith("cnt/")) {
+    return `https://assets.cnt.scot/prod/${stripPrefix(path, "cnt/")}`;
+  }
+
+  return `https://assets.od2net.org/${path}`;
 }
 
 export function ensurePointInVisibleBounds(point: Writable<LngLat>) {

--- a/web/src/title/loader.ts
+++ b/web/src/title/loader.ts
@@ -82,17 +82,17 @@ async function getInputFiles(project: ProjectFeatureCollection): Promise<{
     );
 
     let osmBuffer = await download(
-      assetUrl(`cnt_osm/${project.study_area_name}.osm.pbf`),
+      assetUrl(`cnt/osm/${project.study_area_name}.osm.pbf.gz`),
     );
 
-    let url2 = assetUrl(`cnt_boundaries/${project.study_area_name}.geojson`);
+    let url2 = assetUrl(`cnt/boundaries/${project.study_area_name}.geojson`);
     let resp2 = await safeFetch(url2);
     let boundary = await resp2.json();
 
     let demandBuffer = undefined;
     try {
       demandBuffer = await download(
-        assetUrl(`cnt_demand/demand_${project.study_area_name}.bin`),
+        assetUrl(`cnt/demand/${project.study_area_name}.bin.gz`),
       );
     } catch (err) {
       console.log(`No demand model: ${err}`);
@@ -101,7 +101,7 @@ async function getInputFiles(project: ProjectFeatureCollection): Promise<{
     let contextDataBuffer = undefined;
     try {
       contextDataBuffer = await download(
-        assetUrl(`cnt_prioritization/context_${project.study_area_name}.bin`),
+        assetUrl(`cnt/prioritization/${project.study_area_name}.bin.gz`),
       );
     } catch (err) {
       console.log(`No context data for prioritization: ${err}`);


### PR DESCRIPTION
FIXES #239 and #255

This PR reorganizes the directory structure for CNT assets, from the repetitive "cnt_demand/demand_LAD_foo.bin" structure to "cnt/demand/LAD_foo.bin.gz". Nesting all the CNT directories in one "cnt/" directory lets me organize my local cache of cloudflare R2 locally and have a script to sync it properly.

And secondly, this PR gzips most assets, achieving a big reduction in download time. Browsers will magically gunzip before handing to WASM, thanks to the `content-encoding: gzip` header. For future reference, to get this served by cloudflare (objects stored in R2, with a custom domain `assets.cnt.scot` wired up), it appears impossible to use `rclone`, despite vague docs online suggesting otherwise. After uploading the gzipped objects, I'm doing something like this to set the headers:

```
aws s3 --profile cloudflare \
        --endpoint-url https://FOO.r2.cloudflarestorage.com \
        cp s3://BAR/ s3://BAR/ \
        --exclude '*' \
        --include '*.bin.gz' \
        --include '*.pbf.gz' \
        --no-guess-mime-type \
        --content-type='application/octet-stream' \
        --content-encoding='gzip' \
        --metadata-directive='REPLACE' \
        --recursive
```

@michaelkirk, you'll need to rerun `bin/download-local-dev-data.sh` or regenerate things locally.