### PR TITLE
Show a neighbourhood before edits

### DIFF
--- a/backend/src/map_model.rs
+++ b/backend/src/map_model.rs
@@ -805,6 +805,7 @@ impl MapModel {
         // Clear previous state
         self.boundaries.clear();
         self.modal_filters = self.original_modal_filters.clone();
+        self.diagonal_filters.clear();
         self.turn_restrictions = self.original_turn_restrictions.clone();
         for (r, dir) in &mut self.travel_flows {
             *dir = TravelFlow::from_osm(&self.roads[r.0].tags);

--- a/web/src/common/zorder.ts
+++ b/web/src/common/zorder.ts
@@ -90,10 +90,15 @@ const layerZorder = [
   "debug-filters",
 
   "cells",
+  "before-edits-cells",
   "interior-roads-outlines",
+  "before-edits-interior-roads-outlines",
   "interior-roads",
+  "before-edits-interior-roads",
   "main-roads-outlines",
+  "before-edits-main-roads-outlines",
   "main-roads",
+  "before-edits-main-roads",
   "turn-restriction-targets",
   "debug-intersections",
   "debug-movements-outline",
@@ -101,8 +106,10 @@ const layerZorder = [
   "debug-editable-intersections",
   "editable-intersections",
   "intersection-filters",
+  "before-edits-intersection-filters",
 
   "border-entries",
+  "before-edits-border-entries",
 
   "compare-route",
 
@@ -125,6 +132,7 @@ const layerZorder = [
   "debug-demand-outline",
 
   "one-ways",
+  "before-edits-one-ways",
 
   // Contextual layers cover up most things
   "context-population-car-ownership",
@@ -147,8 +155,11 @@ const layerZorder = [
   "animate-shortcuts",
 
   "modal-filters",
+  "before-edits-modal-filters",
   "turn-restrictions",
+  "before-edits-turn-restrictions",
   "turn-restrictions-debug-arrows",
+  "before-edits-turn-restrictions-debug-arrows",
 
   "boundary",
   "neighbourhood-boundary",

--- a/web/src/edit/ShowBeforeEdits.svelte
+++ b/web/src/edit/ShowBeforeEdits.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import type { FeatureCollection } from "geojson";
+  import { Popup } from "svelte-utils/map";
+  import {
+    CellLayer,
+    ModalFilterLayer,
+    NeighbourhoodRoadLayer,
+    OneWayLayer,
+    RenderNeighbourhood,
+  } from "../layers";
+  import { backend, showBeforeEdits } from "../stores";
+  import type { RenderNeighbourhoodOutput } from "../wasm";
+
+  let prefix = "before-edits-";
+
+  let neighbourhoodGj: RenderNeighbourhoodOutput | null = null;
+  let modalFilterGj: FeatureCollection | null = null;
+  let turnRestrictionGj: FeatureCollection | null = null;
+
+  $: if ($showBeforeEdits && neighbourhoodGj == null) {
+    neighbourhoodGj = $backend!.renderNeighbourhoodBeforeEdits();
+    modalFilterGj = $backend!.renderModalFiltersBeforeEdits();
+    turnRestrictionGj = $backend!.renderTurnRestrictionsBeforeEdits();
+  }
+</script>
+
+{#if neighbourhoodGj}
+  <RenderNeighbourhood input={neighbourhoodGj}>
+    <CellLayer show={$showBeforeEdits} {prefix} />
+    <OneWayLayer show={$showBeforeEdits} {prefix} />
+
+    <NeighbourhoodRoadLayer show={$showBeforeEdits} {prefix} interactive={true}>
+      <div slot="line-popup">
+        <Popup openOn="hover" let:props>
+          {#if props.kind == "interior_road"}
+            <p>
+              {props.shortcuts} shortcuts through {props.name ?? "unnamed road"}
+              ({Math.round(props.speed_mph)} mph)
+            </p>
+          {:else if props.kind == "main_road"}
+            <p>
+              Main road: {props.name ?? "unnamed road"}
+              ({Math.round(props.speed_mph)} mph)
+            </p>
+          {/if}
+        </Popup>
+      </div>
+    </NeighbourhoodRoadLayer>
+  </RenderNeighbourhood>
+{/if}
+
+{#if modalFilterGj && turnRestrictionGj}
+  <ModalFilterLayer
+    {prefix}
+    show={$showBeforeEdits}
+    interactive={false}
+    {modalFilterGj}
+    {turnRestrictionGj}
+  />
+{/if}

--- a/web/src/layers/CellLayer.svelte
+++ b/web/src/layers/CellLayer.svelte
@@ -5,6 +5,9 @@
   import { layerId } from "../common";
   import { drawBorderEntries, roadStyle } from "../stores";
 
+  export let show = true;
+  export let prefix = "";
+
   function borderEntryIconSize(
     scale: number,
   ): DataDrivenPropertyValueSpecification<number> {
@@ -30,10 +33,10 @@
 </script>
 
 <FillLayer
-  {...layerId("cells")}
+  {...layerId(prefix + "cells")}
   filter={["==", ["get", "kind"], "cell"]}
   layout={{
-    visibility: $roadStyle == "cells" ? "none" : "visible",
+    visibility: !show || $roadStyle == "cells" ? "none" : "visible",
   }}
   paint={{
     "fill-color": colorByCellColor(),
@@ -43,7 +46,7 @@
 />
 
 <SymbolLayer
-  {...layerId("border-entries")}
+  {...layerId(prefix + "border-entries")}
   filter={["==", ["get", "kind"], "border_entry"]}
   layout={{
     "icon-image": "border_entry_arrow",
@@ -56,7 +59,7 @@
     // Using bearing is arbitrary, but it's already available and seems to work in practice.
     // Any number which is unique between overlapping icons should suffice.
     "symbol-sort-key": ["get", "bearing_upon_entry"],
-    visibility: $drawBorderEntries ? "visible" : "none",
+    visibility: show && $drawBorderEntries ? "visible" : "none",
   }}
   paint={{
     "icon-color": colorByCellColor(),

--- a/web/src/layers/EditableIntersectionLayer.svelte
+++ b/web/src/layers/EditableIntersectionLayer.svelte
@@ -13,6 +13,7 @@
     getContext("neighbourhoodGj");
   export let onClickIntersection = (intersection: Intersection) => {};
   export let interactive: boolean = false;
+  export let show = true;
 
   /// NOTE: this takes the intersection's index in the neighborhood FeatureCollection, *not* the intersectionId!
   function getIntersectionByFeatureIndex(
@@ -55,6 +56,9 @@
     "circle-stroke-color": Style.mapFeature.hover.backgroundColor,
     "circle-stroke-opacity": 0.8,
     "circle-stroke-width": hoverStateFilter(0, 3),
+  }}
+  layout={{
+    visibility: show ? "visible" : "none",
   }}
   minzoom={13}
   {interactive}

--- a/web/src/layers/NeighbourhoodRoadLayer.svelte
+++ b/web/src/layers/NeighbourhoodRoadLayer.svelte
@@ -25,6 +25,8 @@
   // When disabled, can't click lines or filters, no slots, no hoverCursor
   export let interactive = true;
   export let onClickLine = (f: Feature, pt: LngLat) => {};
+  export let show = true;
+  export let prefix = "";
 
   function roadLineColor(
     style: "shortcuts" | "cells" | "edits" | "speeds",
@@ -92,17 +94,20 @@
 </script>
 
 <LineLayer
-  {...layerId("interior-roads-outlines")}
+  {...layerId(prefix + "interior-roads-outlines")}
   filter={["==", ["get", "kind"], "interior_road"]}
   paint={{
     "line-width": lineWidth($thickRoadsForShortcuts, gj.maxShortcuts, 1),
     "line-color": "black",
   }}
+  layout={{
+    visibility: show ? "visible" : "none",
+  }}
   minzoom={13}
 />
 
 <LineLayer
-  {...layerId("interior-roads")}
+  {...layerId(prefix + "interior-roads")}
   filter={["==", ["get", "kind"], "interior_road"]}
   paint={{
     "line-width": lineWidth($thickRoadsForShortcuts, gj.maxShortcuts, 0),
@@ -111,6 +116,7 @@
   }}
   layout={{
     "line-sort-key": ["get", "shortcuts"],
+    visibility: show ? "visible" : "none",
   }}
   minzoom={13}
   on:click={(e) =>
@@ -124,17 +130,20 @@
 </LineLayer>
 
 <LineLayer
-  {...layerId("main-roads-outlines")}
+  {...layerId(prefix + "main-roads-outlines")}
   filter={["==", ["get", "kind"], "main_road"]}
   paint={{
     "line-width": lineWidth($thickRoadsForShortcuts, gj.maxShortcuts, 6),
     "line-color": "black",
   }}
+  layout={{
+    visibility: show ? "visible" : "none",
+  }}
   minzoom={13}
 />
 
 <LineLayer
-  {...layerId("main-roads")}
+  {...layerId(prefix + "main-roads")}
   filter={["==", ["get", "kind"], "main_road"]}
   paint={{
     "line-width": lineWidth($thickRoadsForShortcuts, gj.maxShortcuts, 4),
@@ -146,6 +155,7 @@
   }}
   layout={{
     "line-sort-key": ["get", "shortcuts"],
+    visibility: show ? "visible" : "none",
   }}
   minzoom={13}
   on:click={(e) =>

--- a/web/src/layers/OneWayLayer.svelte
+++ b/web/src/layers/OneWayLayer.svelte
@@ -2,12 +2,15 @@
   import { SymbolLayer } from "svelte-maplibre";
   import { layerId } from "../common";
 
+  export let show = true;
+  export let prefix = "";
+
   // TODO Figure out if hoverCursor is necessary here, or if svelte-maplibre
   // ignores it when interactive is false
 </script>
 
 <SymbolLayer
-  {...layerId("one-ways")}
+  {...layerId(prefix + "one-ways")}
   filter={[
     "all",
     ["in", ["get", "kind"], ["literal", ["interior_road", "main_road"]]],
@@ -20,11 +23,11 @@
     "symbol-spacing": 50,
     "icon-allow-overlap": true,
     "icon-rotate": ["case", ["==", ["get", "travel_flow"], "forwards"], 0, 180],
+    visibility: show ? "visible" : "none",
   }}
   paint={{
     "icon-opacity": ["case", ["get", "travel_flow_edited"], 1.0, 0.5],
   }}
   minzoom={13}
   interactive={false}
-  hoverCursor="pointer"
 />

--- a/web/src/layers/TurnRestrictionLayer.svelte
+++ b/web/src/layers/TurnRestrictionLayer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Feature, Geometry } from "geojson";
+  import type { Feature, FeatureCollection, Geometry } from "geojson";
   import {
     GeoJSON,
     LineLayer,
@@ -14,6 +14,9 @@
     showExistingFiltersAndTRs,
   } from "../stores";
 
+  export let turnRestrictionGj: FeatureCollection | null = null;
+  export let show = true;
+  export let prefix = "";
   export let onClickTurnRestriction: (
     e: CustomEvent<LayerClickInfo>,
   ) => void = () => {};
@@ -44,12 +47,14 @@
 
   // TODO Runes would make this so nicer. The > 0 part is a hack...
   $: gj =
-    $mutationCounter > 0 ? $backend!.renderTurnRestrictions() : emptyGeojson();
+    $mutationCounter > 0 && turnRestrictionGj == null
+      ? $backend!.renderTurnRestrictions()
+      : emptyGeojson();
 </script>
 
-<GeoJSON data={gj} generateId>
+<GeoJSON data={turnRestrictionGj || gj} generateId>
   <SymbolLayer
-    {...layerId("turn-restrictions")}
+    {...layerId(prefix + "turn-restrictions")}
     minzoom={13}
     filter={$showExistingFiltersAndTRs ? undefined : ["get", "edited"]}
     layout={{
@@ -57,6 +62,7 @@
       "icon-rotate": ["get", "icon_angle"],
       "icon-allow-overlap": true,
       "icon-size": 0.05,
+      visibility: show ? "visible" : "none",
     }}
     paint={{
       "icon-opacity": ["case", ["get", "edited"], 1.0, 0.5],
@@ -70,11 +76,14 @@
 
 <GeoJSON data={showArrow}>
   <LineLayer
-    {...layerId("turn-restrictions-debug-arrows")}
+    {...layerId(prefix + "turn-restrictions-debug-arrows")}
     interactive={false}
     paint={{
       "line-width": 4,
       "line-color": "red",
+    }}
+    layout={{
+      visibility: show ? "visible" : "none",
     }}
   />
 </GeoJSON>

--- a/web/src/stores.ts
+++ b/web/src/stores.ts
@@ -121,6 +121,7 @@ export let mutationCounter: Writable<number> = writable(1);
 export let mode: Writable<Mode> = writable({ mode: "title", firstLoad: true });
 
 // Settings
+export let showBeforeEdits: Writable<boolean> = writable(false);
 export let devMode: Writable<boolean> = writable(false);
 export let maptilerBasemap: Writable<string> = writable("streets-v2");
 export let currentFilterType: Writable<string> = writable("walk_cycle_only");

--- a/web/src/wasm.ts
+++ b/web/src/wasm.ts
@@ -103,21 +103,16 @@ export class Backend {
     return JSON.parse(this.inner.renderModalFilters());
   }
 
-  renderTurnRestrictions(): FeatureCollection<
-    Point,
-    {
-      kind: TurnRestrictionKind;
-      icon_angle: number;
-      // GeoJSON geometries stringified
-      from_geometry: string;
-      to_geometry: string;
-      edited: boolean;
-      intersection: number;
-      from_road: number;
-      to_road: number;
-    }
-  > {
+  renderModalFiltersBeforeEdits(): FeatureCollection {
+    return JSON.parse(this.inner.renderModalFiltersBeforeEdits());
+  }
+
+  renderTurnRestrictions(): TurnRestrictions {
     return JSON.parse(this.inner.renderTurnRestrictions());
+  }
+
+  renderTurnRestrictionsBeforeEdits(): TurnRestrictions {
+    return JSON.parse(this.inner.renderTurnRestrictionsBeforeEdits());
   }
 
   // This adds a 'color' property to all cells. It's nicer to keep this on the
@@ -125,6 +120,21 @@ export class Backend {
   renderNeighbourhood(): RenderNeighbourhoodOutput {
     let gj: RenderNeighbourhoodOutput = JSON.parse(
       this.inner.renderNeighbourhood(),
+    );
+    gj.maxShortcuts =
+      Math.max(
+        ...gj.features.map((f) =>
+          f.properties.kind == "interior_road" ? f.properties.shortcuts : 0,
+        ),
+      ) ?? 0;
+    return gj;
+  }
+
+  // This adds a 'color' property to all cells. It's nicer to keep this on the
+  // frontend, since it's about styling.
+  renderNeighbourhoodBeforeEdits(): RenderNeighbourhoodOutput {
+    let gj: RenderNeighbourhoodOutput = JSON.parse(
+      this.inner.renderNeighbourhoodBeforeEdits(),
     );
     gj.maxShortcuts =
       Math.max(
@@ -241,6 +251,10 @@ export class Backend {
 
   getAllShortcuts(): AllShortcuts {
     return JSON.parse(this.inner.getAllShortcuts());
+  }
+
+  getAllShortcutsBeforeEdits(): AllShortcuts {
+    return JSON.parse(this.inner.getAllShortcutsBeforeEdits());
   }
 
   toSavefile(): ProjectFeatureCollection {
@@ -427,3 +441,18 @@ export interface MetricBuckets {
   collision_density: number[];
   poi_density: number[];
 }
+
+export type TurnRestrictions = FeatureCollection<
+  Point,
+  {
+    kind: TurnRestrictionKind;
+    icon_angle: number;
+    // GeoJSON geometries stringified
+    from_geometry: string;
+    to_geometry: string;
+    edited: boolean;
+    intersection: number;
+    from_road: number;
+    to_road: number;
+  }
+>;


### PR DESCRIPTION
Fixes most of #376.

This introduces a new control to revert all edits and just display the original state of a neighbourhood, so the user can quickly compare.
[Screencast from 13-06-25 08:38:01.webm](https://github.com/user-attachments/assets/912869e8-6465-4ff3-9110-b84e1643e4e1)


Try it out: https://a-b-street.github.io/ltn/before_after_V2
@XioNoX and @TFCx, please see if this achieves what you're trying to do


Questions:

- Is the "Draw roads: edits (either filter or direction)" still useful after this? I think maybe so, if it's a complex area
  - From discussion: YES, keep it
- Does it make sense to also show the original main road classification? Do you ever want to see shortcuts on a current main road, but without any new filters?
  - From discussion: It could be useful sometimes to see the new classification, but the reasonable choice for now is to show the original classification
- Is it OK to only have this feature in the main neighbourhood editing screen? Route mode, predict impact, and impact to one destination all already have a comparison of before/after. Is it useful to use the detailed shortcuts tool on the original state? Or just see all original filters on the pick neighbourhood screen?
  - From discussion: It could help in pick neighbourhood, but the other places don't need it. For now, just have in the edit neighbourhood view.

- [x] Show original turn restrictions
- [ ] Don't show the pointer cursor
- [x] Figure out what happens if you enter this mode in the middle of drawing a turn restriction or something complex
- [x] Figure out what happens if you exit this mode suddenly
- [x] Support animating shortcuts
- [x] Cache the original GJs

Implementation notes:

- I first tried a stateful approach in the backend, making a call to actually revert all of the commands and bump mutationCounter as usual. But restoring the state gets confusing, and so many things need to change on the frontend anyway -- no autosaving while showing the original state. No edits allowed, so all the layer interactivity changes anyway.