### PR TITLE
Put the dev mode toggle in layers

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -53,7 +53,6 @@
   import {
     appFocus as appFocusStore,
     backend,
-    devMode,
     map as mapStore,
     maptilerApiKey,
     maptilerBasemap,
@@ -83,17 +82,6 @@
         console.log("Using local asset files");
       }
     } catch (err) {}
-
-    let devParam = new URLSearchParams(window.location.search).get("dev");
-    if (devParam === "true" || devParam === "") {
-      $devMode = true;
-    } else {
-      console.assert(
-        devParam === null || devParam == "false",
-        `unknown dev mode value: ${devParam}, should be "true", "false", or empty`,
-      );
-      $devMode = false;
-    }
   });
 
   let map: Map | null = null;

--- a/web/src/context/ContextualLayers.svelte
+++ b/web/src/context/ContextualLayers.svelte
@@ -5,6 +5,7 @@
   import {
     appFocus,
     backend,
+    devMode,
     maptilerBasemap,
     showExistingFiltersAndTRs,
   } from "../stores";
@@ -77,6 +78,8 @@
           <option value="hybrid">MapTiler Satellite</option>
           <option value="uk-openzoomstack-light">OS Open Zoomstack</option>
         </select>
+
+        <ContextLayerButton label="Debugging tools" bind:show={$devMode} />
       </div>
     </div>
   </div>


### PR DESCRIPTION
When I'm on the production site, for a variety of reasons (not likely for most users) I need to open something in OSM. Adding `&dev` to the URL and hard-refreshing loses state like the current neighbourhood. So I'm moving the dev mode toggle to layers, where it's reasonably out of the way for most users, but there for anybody who needs it.
![image](https://github.com/user-attachments/assets/6ef4e469-5dd9-432b-a1f2-3f31883c24f8)
