### PR TITLE
Adapt to release candidate geo-buffering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
 [[package]]
 name = "geo"
 version = "0.30.0"
-source = "git+https://github.com/georust/geo?branch=mkirk%2Fgeo-ltn#6ce58f2eda1f06b1596fcabf9e62068bcef09dde"
+source = "git+https://github.com/georust/geo?branch=mkirk%2Fgeo-buffer#27f754f9cd49573be749a3136c545f31ae3027e4"
 dependencies = [
  "earcutr",
  "float_next_after",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [workspace.dependencies]
 anyhow = "1.0.82"
 bincode = "1.3.3"
-geo = { version="0.30.0", git = "https://github.com/georust/geo", branch="mkirk/geo-ltn" }
+geo = { version="0.30.0", git = "https://github.com/georust/geo", branch="mkirk/geo-buffer" }
 geojson = { git = "https://github.com/georust/geojson", features = ["geo-types"] }
 serde = "1.0.188"
 utils = { git = "https://github.com/a-b-street/utils", features = ["serde"] }
@@ -20,7 +20,7 @@ utils = { git = "https://github.com/a-b-street/utils", features = ["serde"] }
 opt-level = 3
 
 [patch.crates-io]
-geo = { git = "https://github.com/georust/geo", branch="mkirk/geo-ltn" }
+geo = { git = "https://github.com/georust/geo", branch="mkirk/geo-buffer" }
 # geo = { path = "../../georust/geo/geo" }
 # geo-types = { path = "../../georust/geo/geo-types" }
 #

--- a/backend/src/boundary_stats.rs
+++ b/backend/src/boundary_stats.rs
@@ -1,5 +1,5 @@
+use geo::buffer::{BufferStyle, LineJoin};
 use geo::{Area, BooleanOps, Buffer, MultiPolygon, Point, Polygon, PreparedGeometry, Relate};
-use i_overlay::mesh::style::{LineJoin, OutlineStyle};
 use serde::{Deserialize, Serialize};
 use utils::Mercator;
 
@@ -94,7 +94,7 @@ impl BoundaryStats {
             // Conclusion: To count incidents on the perimeter, we should buffer a bit more than 1/2
             // the expected road width.
             let buffer_meters = 10.0;
-            let style = OutlineStyle::new(buffer_meters).line_join(LineJoin::Bevel);
+            let style = BufferStyle::new(buffer_meters).line_join(LineJoin::Bevel);
             let buffered_polygon = polygon.buffer_with_style(style);
             let prepared_buffered_polygon = PreparedGeometry::from(&buffered_polygon);
             for pt in &context_data.stats19_collisions {

--- a/backend/src/neighbourhood.rs
+++ b/backend/src/neighbourhood.rs
@@ -90,7 +90,7 @@ impl MapCoordsInPlace<f64> for WayPoints {
 
 impl WayPoint {
     pub fn waypoints_for_ring(ring: &LineString) -> WayPoints {
-        let simplified = ring.simplify(&5.0);
+        let simplified = ring.simplify(5.0);
 
         // ring is closed, so skip the first point, which is redundant with the last
         let coords_iter = simplified.0.iter().skip(1);


### PR DESCRIPTION
Intended to be a no-op change, but adapts to https://github.com/georust/geo/pull/1365 to keep LTN closer to mainline geo.