### PR TITLE
When showing edited roads, also emphasize any edited main roads

### DIFF
--- a/web/src/layers/NeighbourhoodRoadLayer.svelte
+++ b/web/src/layers/NeighbourhoodRoadLayer.svelte
@@ -38,7 +38,7 @@
     prefix = "",
   }: Props = $props();
 
-  function roadLineColor(
+  function interiorRoadLineColor(
     style: "shortcuts" | "cells" | "edits" | "speeds",
     maxShortcuts: number,
   ): DataDrivenPropertyValueSpecification<string> {
@@ -82,6 +82,20 @@
     );
   }
 
+  function mainRoadLineColor(
+    style: "shortcuts" | "cells" | "edits" | "speeds",
+  ): DataDrivenPropertyValueSpecification<string> {
+    if (style == "edits") {
+      return hoverStateFilter(
+        // @ts-expect-error hoverStateFilter is not properly typed - it should accept an expression
+        ["case", ["get", "edited"], signGreen, "gray"],
+        Style.mapFeature.hover.backgroundColor,
+      );
+    }
+
+    return hoverStateFilter("gray", Style.mapFeature.hover.backgroundColor);
+  }
+
   function lineWidth(
     thickRoadsForShortcuts: boolean,
     maxShortcuts: number,
@@ -121,7 +135,7 @@
   filter={["==", ["get", "kind"], "interior_road"]}
   paint={{
     "line-width": lineWidth($thickRoadsForShortcuts, maxShortcuts, 0),
-    "line-color": roadLineColor($roadStyle, maxShortcuts),
+    "line-color": interiorRoadLineColor($roadStyle, maxShortcuts),
     "line-opacity": hoverStateFilter(1.0, 0.5),
   }}
   layout={{
@@ -156,10 +170,7 @@
   filter={["==", ["get", "kind"], "main_road"]}
   paint={{
     "line-width": lineWidth($thickRoadsForShortcuts, maxShortcuts, 4),
-    "line-color": hoverStateFilter(
-      "gray",
-      Style.mapFeature.hover.backgroundColor,
-    ),
+    "line-color": mainRoadLineColor($roadStyle),
     "line-opacity": hoverStateFilter(1.0, 0.5),
   }}
   layout={{

--- a/web/src/locales/en.po
+++ b/web/src/locales/en.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-30T11:22:11.838Z\n"
-"PO-Revision-Date: 2025-09-18T10:22:09.088Z\n"
+"PO-Revision-Date: 2025-09-23T09:40:16.377Z\n"
 "Last-Translator: \n"
 "Language: en\n"
 "Language-Team: \n"
@@ -625,6 +625,7 @@ msgid "POI density <0/>"
 msgstr "POI density <0/>"
 
 #. placeholder {0}: ( neighbourhoodBoundary.properties.number_stats19_collisions / neighbourhoodBoundary.properties.area_km2 ).toFixed(1)
+#. placeholder {0}: ( neighbourhoodBoundary.properties.number_pois / neighbourhoodBoundary.properties.area_km2 ).toFixed(1)
 #: src/common/NeighbourhoodBoundarySummary.svelte
 #: src/common/NeighbourhoodBoundarySummary.svelte
 msgid "{0} / km²"
@@ -670,6 +671,7 @@ msgstr "Street view"
 msgid "Click the map to see street view <0/> <1/> <2>Street view source</2> <3><0/> Google Street View</3> <4><0/> Bing Streetside</4>"
 msgstr "Click the map to see street view <0/> <1/> <2>Street view source</2> <3><0/> Google Street View</3> <4><0/> Bing Streetside</4>"
 
+#. placeholder {0}: existingName
 #. placeholder {0}: existingName
 #: src/pick_neighbourhood/ManageProject.svelte
 #: src/title/TitleMode.svelte

--- a/web/src/locales/fr.po
+++ b/web/src/locales/fr.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-30T11:22:11.897Z\n"
-"PO-Revision-Date: 2025-09-18T10:22:09.339Z\n"
+"PO-Revision-Date: 2025-09-23T09:40:16.651Z\n"
 "Last-Translator: \n"
 "Language: fr\n"
 "Language-Team: \n"
@@ -577,6 +577,7 @@ msgid "POI density <0/>"
 msgstr ""
 
 #. placeholder {0}: ( neighbourhoodBoundary.properties.number_stats19_collisions / neighbourhoodBoundary.properties.area_km2 ).toFixed(1)
+#. placeholder {0}: ( neighbourhoodBoundary.properties.number_pois / neighbourhoodBoundary.properties.area_km2 ).toFixed(1)
 #: src/common/NeighbourhoodBoundarySummary.svelte
 #: src/common/NeighbourhoodBoundarySummary.svelte
 msgid "{0} / km²"
@@ -622,6 +623,7 @@ msgstr ""
 msgid "Click the map to see street view <0/> <1/> <2>Street view source</2> <3><0/> Google Street View</3> <4><0/> Bing Streetside</4>"
 msgstr ""
 
+#. placeholder {0}: existingName
 #. placeholder {0}: existingName
 #: src/pick_neighbourhood/ManageProject.svelte
 #: src/title/TitleMode.svelte

--- a/web/src/locales/hu.po
+++ b/web/src/locales/hu.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-30T11:22:11.919Z\n"
-"PO-Revision-Date: 2025-09-18T10:22:09.535Z\n"
+"PO-Revision-Date: 2025-09-23T09:40:16.741Z\n"
 "Last-Translator: \n"
 "Language: hu\n"
 "Language-Team: \n"
@@ -573,6 +573,7 @@ msgid "POI density <0/>"
 msgstr ""
 
 #. placeholder {0}: ( neighbourhoodBoundary.properties.number_stats19_collisions / neighbourhoodBoundary.properties.area_km2 ).toFixed(1)
+#. placeholder {0}: ( neighbourhoodBoundary.properties.number_pois / neighbourhoodBoundary.properties.area_km2 ).toFixed(1)
 #: src/common/NeighbourhoodBoundarySummary.svelte
 #: src/common/NeighbourhoodBoundarySummary.svelte
 msgid "{0} / km²"
@@ -618,6 +619,7 @@ msgstr ""
 msgid "Click the map to see street view <0/> <1/> <2>Street view source</2> <3><0/> Google Street View</3> <4><0/> Bing Streetside</4>"
 msgstr ""
 
+#. placeholder {0}: existingName
 #. placeholder {0}: existingName
 #: src/pick_neighbourhood/ManageProject.svelte
 #: src/title/TitleMode.svelte


### PR DESCRIPTION
Related to #70.

Edits like new one-ways on a main road are very important to highlight too, so include them in the styling.
<img width="2402" height="1030" alt="image" src="https://github.com/user-attachments/assets/18235d56-1c4c-4a7b-8427-b26ce8c3c78d" />
